### PR TITLE
fix: 注销系统后默认程序设置失效

### DIFF
--- a/src/modules/mimeapp/mime_app.cpp
+++ b/src/modules/mimeapp/mime_app.cpp
@@ -221,6 +221,12 @@ void MimeApp::initConfigData()
         std::string validAppId;
 
         for (auto type : defaultApp.supportedType) {
+            // 如果之前用户有修改默认程序，在每次初始化时不应该再使用配置文件里面的默认程序
+            std::string appId = AppInfoManger::getDefaultApp(type.toString().toStdString(), false);
+            if (!appId.empty()) {
+                continue;
+            }
+
             if (!validAppId.empty()) {
                 if (setDefaultApp(type.toString().toStdString(), validAppId)) {
                     continue;


### PR DESCRIPTION
如果用户有通过控制中心修改默认程序，每次重新登录系统使用之前用户设置的默认程序
而不是从配置文件中重新加载

Log: 修复注销系统后默认程序设置失效的问题
Bug: https://github.com/linuxdeepin/developer-center/issues/3591
Influence: 控制中心默认程序设置