### PR TITLE
fix: fix get a longer name then it actually is

### DIFF
--- a/src/lib/xcbutils.cpp
+++ b/src/lib/xcbutils.cpp
@@ -359,7 +359,7 @@ std::string XCBUtils::getWMName(XWindow xid)
     xcb_get_property_cookie_t cookie = xcb_ewmh_get_wm_name(&m_ewmh, xid);
     xcb_ewmh_get_utf8_strings_reply_t reply;
     if (xcb_ewmh_get_wm_name_reply(&m_ewmh, cookie, &reply, nullptr)) {
-        ret.assign(reply.strings);
+        ret.assign(reply.strings, reply.strings_len);
         // 释放utf8_strings_reply分配的内存
         xcb_ewmh_get_utf8_strings_reply_wipe(&reply);
     } else {


### PR DESCRIPTION
fix https://github.com/linuxdeepin/developer-center/issues/3763 
the full character which `xcb_ewmh_get_wm_name` returns  is longer than wm name,
get the same length character as the wm name instead of full character .

log: