### PR TITLE
fix: 任务栏应用图标显示异常

### DIFF
--- a/src/modules/dock/windowidentify.cpp
+++ b/src/modules/dock/windowidentify.cpp
@@ -127,6 +127,8 @@ AppInfo *WindowIdentify::identifyWindowX11(WindowInfoX *winInfo, QString &innerI
     }
 
     qInfo() << "identifyWindowX11: failed";
+    // 如果识别窗口失败，则该app的entryInnerId使用当前窗口的innerId
+    innerId = winInfo->getInnerId();
     return appInfo;
 }
 

--- a/src/modules/dock/windowinfobase.h
+++ b/src/modules/dock/windowinfobase.h
@@ -5,6 +5,7 @@
 #ifndef WINDOWINFOBASE_H
 #define WINDOWINFOBASE_H
 
+#include "processinfo.h"
 #include "xcbutils.h"
 
 #include <QString>
@@ -12,7 +13,6 @@
 
 class Entry;
 class AppInfo;
-class ProcessInfo;
 
 class WindowInfoBase
 {
@@ -23,7 +23,6 @@ public:
             delete processInfo;
         }
     }
-
 
     virtual bool shouldSkip() = 0;
     virtual QString getIcon() = 0;


### PR DESCRIPTION
对于某些没有提供desktop文件（或者desktop文件中没有指定Icon字段）的应用
需要从窗管获取应用的Icon

Log: 修复任务栏应用图标显示异常的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3811
Influence: 任务栏应用图片显示