### PR TITLE
chore: bump version to 1.0.9

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -74,7 +74,7 @@ Copyright: None
 License: CC0-1.0
 
 # xml json conf yaml
-Files: .clog.toml .tx/config dbus/*.xml misc/*/*.service misc/*/*.json src/*.in src/frameworkdbus/*
+Files: .clog.toml .tx/* dbus/*.xml misc/*/*.service misc/*/*.json src/*.in src/frameworkdbus/*
 Copyright: None
 License: CC0-1.0
 

--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,0 +1,2 @@
+[transifex]
+branch = m20

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+dde-application-manager (1.0.9) unstable; urgency=medium
+
+  * fix get a longer name then it actually is
+  * fix abnormal icon display in the dock
+  * set fullscreen launcher by default
+  * fix default application resets after relogin
+  * fix crash when get windowicon
+  * fix app proxy invalid
+  * fix invalid appid
+
+ -- zsien <quezhiyong@uniontech.com>  Wed, 29 Mar 2023 13:14:37 +0800
+
 dde-application-manager (1.0.8) unstable; urgency=medium
 
   [ TagBuilder ]


### PR DESCRIPTION
* fix get a longer name then it actually is
* fix abnormal icon display in the dock
* set fullscreen launcher by default
* fix default application resets after relogin
* fix crash when get windowicon
* fix app proxy invalid
* fix invalid appid