### PR TITLE
fix some window identify issues

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends:
  libdtkcore-dev (>=5.4.14),
  libdtkcore5-bin (>=5.4.14),
  libxcb1-dev,
+ libxres-dev,
  libxcb-icccm4-dev,
  libxcb-ewmh-dev,
  libx11-dev,

--- a/src/modules/dock/windowidentify.cpp
+++ b/src/modules/dock/windowidentify.cpp
@@ -68,19 +68,18 @@ WindowIdentify::WindowIdentify(Dock *_dock, QObject *parent)
  : QObject(parent)
  , m_dock(_dock)
 {
-    m_identifyWindowFuns["Android"] = identifyWindowAndroid;
-    m_identifyWindowFuns["PidEnv"] = identifyWindowByPidEnv;
-    m_identifyWindowFuns["CmdlineTurboBooster"] = identifyWindowByCmdlineTurboBooster;
-    m_identifyWindowFuns["Cmdline-XWalk"] = identifyWindowByCmdlineXWalk;
-    m_identifyWindowFuns["FlatpakAppID"] = identifyWindowByFlatpakAppID;
-    m_identifyWindowFuns["CrxId"] = identifyWindowByCrxId;
-    m_identifyWindowFuns["Rule"] = identifyWindowByRule;
-    m_identifyWindowFuns["Bamf"] = identifyWindowByBamf;
-    m_identifyWindowFuns["Pid"] = identifyWindowByPid;
-    m_identifyWindowFuns["Scratch"] = identifyWindowByScratch;
-    m_identifyWindowFuns["GtkAppId"] = identifyWindowByGtkAppId;
-    m_identifyWindowFuns["WmClass"] = identifyWindowByWmClass;
-
+    m_identifyWindowFuns << qMakePair(QString("Android") , &identifyWindowAndroid);
+    m_identifyWindowFuns << qMakePair(QString("PidEnv"), &identifyWindowByPidEnv);
+    m_identifyWindowFuns << qMakePair(QString("CmdlineTurboBooster"), &identifyWindowByCmdlineTurboBooster);
+    m_identifyWindowFuns << qMakePair(QString("Cmdline-XWalk"), &identifyWindowByCmdlineXWalk);
+    m_identifyWindowFuns << qMakePair(QString("FlatpakAppID"), &identifyWindowByFlatpakAppID);
+    m_identifyWindowFuns << qMakePair(QString("CrxId"), &identifyWindowByCrxId);
+    m_identifyWindowFuns << qMakePair(QString("Rule"), &identifyWindowByRule);
+    m_identifyWindowFuns << qMakePair(QString("Bamf"), &identifyWindowByBamf);
+    m_identifyWindowFuns << qMakePair(QString("Pid"), &identifyWindowByPid);
+    m_identifyWindowFuns << qMakePair(QString("Scratch"), &identifyWindowByScratch);
+    m_identifyWindowFuns << qMakePair(QString("GtkAppId"), &identifyWindowByGtkAppId);
+    m_identifyWindowFuns << qMakePair(QString("WmClass"), &identifyWindowByWmClass);
 }
 
 AppInfo *WindowIdentify::identifyWindow(WindowInfoBase *winInfo, QString &innerId)
@@ -106,8 +105,8 @@ AppInfo *WindowIdentify::identifyWindowX11(WindowInfoX *winInfo, QString &innerI
     }
 
     for (auto iter = m_identifyWindowFuns.begin(); iter != m_identifyWindowFuns.end(); iter++) {
-        QString name = iter.key();
-        IdentifyFunc func = iter.value();
+        QString name = iter->first;
+        IdentifyFunc func = iter->second;
         qInfo() << "identifyWindowX11: try " << name;
         appInfo = func(m_dock, winInfo, innerId);
         if (appInfo) {  // TODO: if name == "Pid", appInfo may by nullptr

--- a/src/modules/dock/windowidentify.h
+++ b/src/modules/dock/windowidentify.h
@@ -50,7 +50,7 @@ private:
 
 private:
     Dock *m_dock;
-    QMap<QString, IdentifyFunc> m_identifyWindowFuns;
+    QList<QPair<QString, IdentifyFunc>> m_identifyWindowFuns;
 };
 
 #endif // IDENTIFYWINDOW_H

--- a/src/modules/startmanager/startmanager.cpp
+++ b/src/modules/startmanager/startmanager.cpp
@@ -431,6 +431,12 @@ bool StartManager::launch(DesktopInfo *info, QString cmdLine, uint32_t timestamp
     process.setProgram(exec);
     process.setArguments(exeArgs);
     process.setWorkingDirectory(workingDir.c_str());
+
+    // NOTE(black_desk): This have to be done after load system environment.
+    // Set same env twice in qt make the first one gone.
+    envs << QString("GIO_LAUNCHED_DESKTOP_FILE=") +
+            QString::fromStdString(info->getDesktopFile()->getFilePath());
+
     process.setEnvironment(envs);
     qint64 pid = 0;
     if (process.startDetached(&pid)) {

--- a/src/modules/startmanager/startmanager.cpp
+++ b/src/modules/startmanager/startmanager.cpp
@@ -426,7 +426,7 @@ bool StartManager::launch(DesktopInfo *info, QString cmdLine, uint32_t timestamp
     exeArgs.removeAt(0);
 
     qDebug() << "Launching app, desktop: " << QString::fromStdString(info->getFileName()) << " exec:  " << exec
-             << " args:   " << exeArgs << " useProxy:" << useProxy << "appid:" << appId;
+             << " args:   " << exeArgs << " useProxy:" << useProxy << "appid:" << appId << "envs:" << envs;
 
     process.setProgram(exec);
     process.setArguments(exeArgs);

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(DtkWidget REQUIRED)
 
 pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb-icccm xcb-ewmh xcb)
 pkg_check_modules(X11 REQUIRED IMPORTED_TARGET x11)
+pkg_check_modules(XRes REQUIRED IMPORTED_TARGET xres)
 pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0 gio-unix-2.0)
 pkg_check_modules(GLib REQUIRED IMPORTED_TARGET glib-2.0)
 pkg_check_modules(QGSettings REQUIRED IMPORTED_TARGET gsettings-qt)
@@ -57,6 +58,7 @@ target_link_libraries(${BIN_NAME}
     pthread
     PkgConfig::XCB
     PkgConfig::X11
+    PkgConfig::XRes
     PkgConfig::GIO
     PkgConfig::GLib
     PkgConfig::QGSettings
@@ -66,6 +68,7 @@ target_link_libraries(${BIN_NAME}
 target_include_directories(${BIN_NAME} PUBLIC
     PkgConfig::XCB
     PkgConfig::X11
+    PkgConfig::XRes
     PkgConfig::GIO
     PkgConfig::GLib
     PkgConfig::QGSettings


### PR DESCRIPTION
Code copy from https://gitlab.gnome.org/GNOME/metacity/-/merge_requests/13/diffs

The xprop `_NET_WM_PID` is set by the client side, even if the process
in running in some container. But when pid_ns is unshared, the processes
in side a container, will not be able to get the "right" pid of itself.

The "new" XResQueryClientIds added to XRes will fix this issue by
produce the pid in server side.

refs:

- https://gitlab.freedesktop.org/xorg/xserver/-/issues/1022#note_497597
- https://www.x.org/releases/X11R7.7/doc/resourceproto/resproto.txt

close linuxdeepin/developer-center#3802
