### PR TITLE
fix: 应用无法打开选中的多个文件

### DIFF
--- a/src/modules/startmanager/startmanager.cpp
+++ b/src/modules/startmanager/startmanager.cpp
@@ -622,14 +622,11 @@ void StartManager::handleRecognizeArgs(QStringList &exeArgs, QStringList files)
         // > A single file name (including the path), even if multiple files are selected.
         exeArgs.replaceInStrings("%f", files.at(0));
     } else if (!exeArgs.filter("%F").isEmpty()) {
-        QStringList urlList;
+        exeArgs.removeOne("%F");
         for (const QString &file : files) {
             QUrl url(file);
-            urlList.append(url.toLocalFile());
+            exeArgs << url.toLocalFile();
         }
-
-        const QString &fileUlr = urlList.join(" ");
-        exeArgs.replaceInStrings("%F", fileUlr);
     } else if (!exeArgs.filter("%u").isEmpty()) {
         exeArgs.replaceInStrings("%u", files.at(0));
     } else if (!exeArgs.filter("%U").isEmpty()) {


### PR DESCRIPTION
此处不应该将多个文件的路径拼接成一个异常(不存在)的路径,
而应该将多个文件的路径分开传入

Log: 修复应用无法打开选中的多个文件的问题
Reslove: https://github.com/linuxdeepin/developer-center/issues/4005
Influence: 应用打开多个文件