### PR TITLE
fix: 卸载玲珑应用时，部分行为异常

### DIFF
--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -555,6 +555,7 @@ void Launcher::onCheckDesktopFile(const QString &filePath, int type)
             // remove item
             const Item &item = itemsMap[filePath];
             removeDesktop(filePath);
+
             emitItemChanged(&item, appStatusDeleted);
         }
     }
@@ -982,6 +983,8 @@ void Launcher::doUninstall(DesktopInfo &info, const Item &item)
             qWarning() << QString("uninstall %1 failed...").arg(info.getFileName().c_str());
             return;
         }
+
+        removeDesktop(item.info.path);
 
         Q_EMIT uninstallSuccess(item.info.path);
 

--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -714,11 +714,7 @@ void Launcher::addItem(Item &item)
     itemsMap[item.info.id] = item;
 
     QFileInfo desktopInfo(item.info.path);
-    if (desktopInfo.isSymLink()) {
-        m_desktopAndItemMap[desktopInfo.symLinkTarget()] = item;
-    } else {
-        m_desktopAndItemMap[item.info.path] = item;
-    }
+    m_desktopAndItemMap[item.info.path] = item;
 }
 
 Categorytype Launcher::queryCategoryId(const Item *item)


### PR DESCRIPTION
1. 修复使用ll-cli终端卸载玲珑应用后，启动器图标依然存在的问题。
2. 修复右键点击启动器图标卸载玲珑应用，发送到桌面的文件依然存在的问题。
close #developer-center/issues/3611