### PR TITLE
fix: 卸载flatpak应用文件未关闭

### DIFF
--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -1056,6 +1056,7 @@ void Launcher::uninstallFlatpak(DesktopInfo &info, const Item &item)
             return;
 
         QString content(file.readAll());
+        file.close();
         QString pkgName = content.trimmed();
         uninstallApp(item.info.name, pkgName);
     } else {


### PR DESCRIPTION
launcher.cpp文件的uninstallFlatpak函数中有一处文件未关闭的bug，尝试修复之。

Log: 修复卸载flatpak应用文件未关闭的bug