### PR TITLE
fix: don't use bamf on wayland session

### DIFF
--- a/src/modules/dock/common.h
+++ b/src/modules/dock/common.h
@@ -74,4 +74,17 @@ const int MotifFunctionClose = 32;
 
 const QString ddeLauncherWMClass = "dde-launcher";
 
+static inline QByteArray sessionType() {
+    static QByteArray type = qgetenv("XDG_SESSION_TYPE");
+    return type;
+}
+
+static inline bool isWaylandSession() {
+    return sessionType().compare("wayland") == 0;
+}
+
+static inline bool isX11Session() {
+    return sessionType().compare("x11") == 0;
+}
+
 #endif // COMMON_H

--- a/src/modules/dock/dbushandler.cpp
+++ b/src/modules/dock/dbushandler.cpp
@@ -30,7 +30,7 @@ DBusHandler::DBusHandler(Dock *_dock, QObject *parent)
     // 关联org.deepin.dde.WMSwitcher1事件 WMChanged
     connect(m_wmSwitcher, &__WMSwitcher::WMChanged, this, [&](QString name) {m_dock->setWMName(name);});
 
-    if (QString(getenv("XDG_SESSION_TYPE")).contains("wayland")) {
+    if (isWaylandSession()) {
         m_xEventMonitor = new org::deepin::dde::XEventMonitor1("org.deepin.dde.XEventMonitor1", "/org/deepin/dde/XEventMonitor1", m_session, this);
         // 注册XEventMonitor区域为整个屏幕的区域
         m_activeWindowMonitorKey = m_xEventMonitor->RegisterFullScreen();

--- a/src/modules/dock/dock.cpp
+++ b/src/modules/dock/dock.cpp
@@ -40,17 +40,17 @@ Dock::Dock(ApplicationManager *applicationManager, QObject *parent)
 {
     registeModule("dock");
 
-    QString sessionType {getenv("XDG_SESSION_TYPE")};
-    qInfo() << "sessionType=" << sessionType;
-    if (sessionType.contains("wayland")) {
+    if (isWaylandSession()) {
         // wayland env
         m_isWayland = true;
         m_waylandManager = new WaylandManager(this);
         m_dbusHandler->listenWaylandWMSignals();
-    } else if (sessionType.contains("x11")) {
+    } else if (isX11Session()) {
         // x11 env
         m_isWayland = false;
         m_x11Manager = new X11Manager(this);
+    } else {
+        qFatal("Unknown XDG_SESSION_TYPE '%s'", sessionType().constData());
     }
 
     initSettings();

--- a/src/modules/dock/windowidentify.cpp
+++ b/src/modules/dock/windowidentify.cpp
@@ -163,31 +163,6 @@ AppInfo *WindowIdentify::identifyWindowWayland(WindowInfoK *winInfo, QString &in
             appInfo = fixedAppInfo;
             appInfo->setIdentifyMethod("FixAutostart");
         }
-    } else {
-        // bamf
-        XWindow winId = winInfo->getXid();
-        QString desktop = m_dock->getDesktopFromWindowByBamf(winId);
-        if (!desktop.isEmpty()) {
-            appInfo = new AppInfo(desktop);
-        }
-
-        WMClass wmClass = XCB->getWMClass(winId);
-        if (wmClass.instanceName.size() > 0) {
-            QString instance(wmClass.instanceName.c_str());
-            appInfo = new AppInfo("org.deepin.flatdeb." + instance);
-            if (appInfo)
-                return appInfo;
-
-            appInfo = new AppInfo(instance);
-            if (appInfo)
-                return appInfo;
-
-            if (wmClass.className.size() > 0) {
-                appInfo = new AppInfo(wmClass.className.c_str());
-                if (appInfo)
-                    return appInfo;
-            }
-        }
     }
 
     if (appInfo)
@@ -421,6 +396,10 @@ AppInfo *WindowIdentify::identifyWindowByRule(Dock *_dock, WindowInfoX *winInfo,
 
 AppInfo *WindowIdentify::identifyWindowByBamf(Dock *_dock, WindowInfoX *winInfo, QString &innerId)
 {
+    if (_dock->isWaylandEnv()) {
+        return nullptr;
+    }
+
     AppInfo *ret = nullptr;
     XWindow xid = winInfo->getXid();
     qInfo() << "identifyWindowByBamf:  windowId=" << xid;


### PR DESCRIPTION
The bamfdaemon is needs X server, it's crash on XWayland.