### PR TITLE
fix: 退出没有图标的应用AM崩溃

### DIFF
--- a/src/lib/xcbutils.h
+++ b/src/lib/xcbutils.h
@@ -44,11 +44,10 @@ typedef struct {
     uint32_t status;
 } MotifWMHints;
 
-typedef unsigned char BYTE;
 typedef struct {
   uint32_t width;   /** Icon width */
   uint32_t height;  /** Icon height */
-  std::vector<BYTE> data;   /** Rows, left to right and top to bottom of the CARDINAL ARGB */
+  std::vector<uint32_t> data;   /** Rows, left to right and top to bottom of the CARDINAL ARGB */
 } WMIcon;
 
 typedef struct WindowFrameExtents {
@@ -202,7 +201,7 @@ public:
     std::string getWMIconName(XWindow xid);
 
     // 获取窗口图标信息 _NET_WM_ICON
-    std::vector<WMIcon> getWMIcon(XWindow xid);
+    WMIcon getWMIcon(XWindow xid);
 
     // WM_CLIENT_LEADER
     XWindow getWMClientLeader(XWindow xid);


### PR DESCRIPTION
使用xcb ewmh的相关接口获取应用icon

Log: 修复没有图标的应用退出时AM奔溃退出的问题
Influence: 任务栏应用图标正常显示