### PR TITLE
fix: error handling recognized args

### DIFF
--- a/src/modules/startmanager/startmanager.cpp
+++ b/src/modules/startmanager/startmanager.cpp
@@ -661,10 +661,8 @@ void StartManager::handleRecognizeArgs(QStringList &exeArgs, QStringList files)
     // > codes must be removed from the command line and ignored.
 
     if (files.isEmpty()) {
-        for (QString &exeArg: exeArgs) {
-            for (const QString &arg : argList) {
-                exeArg.replace(arg, "");
-            }
+        for (const QString &arg : argList) {
+            exeArgs.removeAll(arg);
         }
         return;
     }


### PR DESCRIPTION
Recognized args should be removed from exec args when there are no actual contents. instead of being replaced by "".

Log: fix error handling recognized args