### PR TITLE
fix: use application-x-executable when uninstall finished

### DIFF
--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -1142,14 +1142,14 @@ void Launcher::notifyUninstallDone(const Item &item, bool result)
 {
     QString msg;
     if (result)
-        msg = QString(tr("Removed successfully"));
+        msg = tr("%1 removed successfully").arg(item.info.name);
     else
-        msg = QString(tr("Failed to remove the app"));
+        msg = tr("Failed to remove the app");
 
     QList<QVariant> argList;
-    argList << QString("deepin-app-store")
+    argList << QStringLiteral("deepin-app-store")
             << quint32(0)
-            << QString("deepin-app-store")
+            << QStringLiteral("application-x-executable")
             << msg
             << QString("")
             << QStringList("")


### PR DESCRIPTION
需求变动，卸载完成后的指示图标使用 application-x-executable，并在通知内容中展示所卸载的应用名称。

TODO:

- [ ] 确定卸载时的文案，并更新翻译。
- [ ] 确定效果是否属于预期，被卸载的应用程序名称是否可以正常展示。