### PR TITLE
fix: add missing header for clang

### DIFF
--- a/src/lib/applaunchcontext.h
+++ b/src/lib/applaunchcontext.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class DesktopInfo;
 class AppLaunchContext

--- a/src/lib/keyfile.h
+++ b/src/lib/keyfile.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <cstdint>
 
 typedef std::map<std::string, std::string> KeyMap;
 typedef std::map<std::string, KeyMap> MainKeyMap;


### PR DESCRIPTION
Clang need these header to be included for definition of uint32_t and
uint64_t.
