### PR TITLE
fix: early return in WindowIdentify::identifyWindowByPidEnv

### DIFF
--- a/src/modules/dock/windowidentify.cpp
+++ b/src/modules/dock/windowidentify.cpp
@@ -208,6 +208,10 @@ AppInfo *WindowIdentify::identifyWindowByPidEnv(Dock *_dock, WindowInfoX *winInf
     int launchedDesktopFilePid = launchedDesktopFilePidStr.toInt();
     qInfo() << "launchedDesktopFilePid=" << launchedDesktopFilePid << " launchedDesktopFile=" << launchedDesktopFile;
 
+    if (launchedDesktopFile.isEmpty()) {
+            return ret;
+    }
+
     auto pidIsSh = [](int pid) -> bool {
         Process parentProcess(pid);
         auto parentCmdLine = parentProcess.getCmdLine();


### PR DESCRIPTION
If we cannot get desktop file from env, we should just failed.
