### PR TITLE
 fix: void register signal handler for SIG_CHILD

### DIFF
--- a/src/modules/startmanager/startmanager.h
+++ b/src/modules/startmanager/startmanager.h
@@ -40,11 +40,10 @@ public Q_SLOTS:
     void onAutoStartupPathChange(const QString &dirPath);
 
 private:
-    void waitForDeadChild();
     bool setAutostart(const QString &fileName, const bool value);
     bool doLaunchAppWithOptions(const QString &desktopFile);
     bool doLaunchAppWithOptions(QString desktopFile, uint32_t timestamp, QStringList files, QVariantMap options);
-    bool launch(DesktopInfo *info, QString cmdLine, uint32_t timestamp, QStringList files);
+    void launch(DesktopInfo *info, QString cmdLine, uint32_t timestamp, QStringList files);
     bool doRunCommandWithOptions(QString exe, QStringList args, QVariantMap options);
     void waitCmd(DesktopInfo *info, QProcess *process, QString cmdName);
     bool shouldUseProxy(QString appId);


### PR DESCRIPTION
linuxdeepin/developer-center#4412

QProcess::execute will use waitid to get exit code of that process it
starts. Register SIG_CHILD and wait all dead childs will break this
mechanism, as QProcess will find out that there is no child to wait,
and report this situation as a child process exit by crash.

So I change the method of launch application to use a double fork, to
start process and detach. Just as the way `QProcess` get this job done
in its `startDetached` method.

As a quick fix, I change the signature of `launch` method as no one use
its return value currently. If this is need someday, we should use a
pipe to let double forked child process report the return value and
errno of its `exec` call.