### PR TITLE
fix: icon is not displayed after a package installed

### DIFF
--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -544,11 +544,14 @@ void Launcher::onCheckDesktopFile(const QString &filePath, int type)
                 emitItemChanged(&newItem, appStatusDeleted);
             }
         } else if (shouldShow) {
-            if (info.isExecutableOk()) {
-                // add item
-                addItem(newItem);
-                emitItemChanged(&newItem, appStatusCreated);
-            }
+            // quickFix: 1000ms delay, waiting for the debian trigger link to complete.
+            QTimer::singleShot(1000, this, [this, info , newItem]() mutable -> void {
+                if (info.isExecutableOk()) {
+                    // add item
+                    addItem(newItem);
+                    emitItemChanged(&newItem, appStatusCreated);
+                }
+            });
         }
     } else {
         if (m_desktopAndItemMap.find(filePath) != m_desktopAndItemMap.end()) {


### PR DESCRIPTION
When we install the package which binary packed in /opt, the trigger will link the desktop file and binary to /usr. 
But it links desktop file first and AM can not find the program of the package in any path of $PATH at that moment. Then the signal which named ItemChanged is not emited by AM and launcher will not display the icon.

This is a quick fix, wait 1000ms until the binary link is complete.

close: linuxdeepin/developer-center#4487