### PR TITLE
fix: don't check full path for launcher

### DIFF
--- a/src/modules/launcher/common.h
+++ b/src/modules/launcher/common.h
@@ -36,7 +36,4 @@ const QString appStatusDeleted  = "deleted";
 
 // flatpak应用
 const QString flatpakBin = "flatpak";
-
-// 启动器执行程序
-const QString launcherExe = "/usr/bin/dde-launcher";
 #endif // COMMON_H

--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -288,7 +288,7 @@ void Launcher::requestUninstall(const QString &desktop)
     process.waitForReadyRead();
     QString result = QString::fromUtf8(process.readAllStandardOutput());
     process.close();
-    if (result != launcherExe) {
+    if (!result.endsWith(QStringLiteral("dde-launcher"))) {
         qWarning() << result << " has no right to uninstall " << appDesktopPath;
         return;
     }


### PR DESCRIPTION
不以完整路径来检查进行卸载请求的应用是不是 dde-launcher。

注意，这里原本进行的检查本身是不合理的，本身也很容易被绕过。后续应当以其他的形式确保卸载接口不被滥用。
