### PR TITLE
fix: 卸载第三方应用后任务栏依然显示应用

### DIFF
--- a/src/modules/launcher/launcher.cpp
+++ b/src/modules/launcher/launcher.cpp
@@ -556,7 +556,7 @@ void Launcher::onCheckDesktopFile(const QString &filePath, int type)
     } else {
         if (m_desktopAndItemMap.find(filePath) != m_desktopAndItemMap.end()) {
             // remove item
-            const Item &item = itemsMap[filePath];
+            const Item &item = m_desktopAndItemMap[filePath];
             removeDesktop(filePath);
 
             emitItemChanged(&item, appStatusDeleted);


### PR DESCRIPTION
应该使用m_desktopAndItemMap而不是itemsMap去获取对应的Item

Log: 修复卸载第三方应用后任务栏依然显示应用的问题
Influence: 任务栏应用正常显示
Resolve: https://github.com/linuxdeepin/developer-center/issues/4630