### PR TITLE
fix: core dumped under Qt 6.4

### DIFF
--- a/apps/dde-application-manager/src/main.cpp
+++ b/apps/dde-application-manager/src/main.cpp
@@ -26,6 +26,7 @@ void registerComplexDbusType()
     qDBusRegisterMetaType<QMap<QString, QString>>();
     qRegisterMetaType<PropMap>();
     qDBusRegisterMetaType<PropMap>();
+    qDBusRegisterMetaType<QDBusObjectPath>();
 }
 }  // namespace
 

--- a/src/constant.h
+++ b/src/constant.h
@@ -35,4 +35,11 @@ constexpr auto ApplicationManagerDestDBusName =
     u8"deepin_application_manager_dest_bus";
 #endif
 
+constexpr auto ObjectManagerInterface = "org.desktopspec.DBus.ObjectManager";
+constexpr auto JobManagerInterface = "org.desktopspec.JobManager1";
+constexpr auto JobInterface = "org.desktopspec.JobManager1.Job";
+constexpr auto ApplicationManagerInterface = "org.desktopspec.ApplicationManager1";
+constexpr auto InstanceInterface = "org.desktopspec.ApplicationManager1.Instance";
+constexpr auto ApplicationInterface = "org.desktopspec.ApplicationManager1.Application";
+
 #endif

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -28,8 +28,7 @@ ApplicationManager1Service::ApplicationManager1Service(std::unique_ptr<Identifie
         std::terminate();
     }
 
-    if (!registerObjectToDBus(
-            this, DDEApplicationManager1ObjectPath, getDBusInterface(QMetaType::fromType<ApplicationManager1Adaptor>()))) {
+    if (!registerObjectToDBus(this, DDEApplicationManager1ObjectPath, ApplicationManagerInterface)) {
         std::terminate();
     }
 
@@ -130,8 +129,7 @@ bool ApplicationManager1Service::addApplication(DesktopFile desktopFileSource) n
         return false;
     }
 
-    if (!registerObjectToDBus(
-            ptr, application->applicationPath().path(), getDBusInterface(QMetaType::fromType<ApplicationAdaptor>()))) {
+    if (!registerObjectToDBus(ptr, application->applicationPath().path(), ApplicationInterface)) {
         return false;
     }
     m_applicationList.insert(application->applicationPath(), application);

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -317,7 +317,7 @@ bool ApplicationService::addOneInstance(const QString &instanceId, const QString
     auto *adaptor = new InstanceAdaptor(service);
     QString objectPath{m_applicationPath.path() + "/" + instanceId};
 
-    if (registerObjectToDBus(service, objectPath, getDBusInterface(QMetaType::fromType<InstanceAdaptor>()))) {
+    if (registerObjectToDBus(service, objectPath, InstanceInterface)) {
         m_Instances.insert(QDBusObjectPath{objectPath}, QSharedPointer<InstanceService>{service});
         service->moveToThread(this->thread());
         adaptor->moveToThread(this->thread());

--- a/src/dbus/jobmanager1service.cpp
+++ b/src/dbus/jobmanager1service.cpp
@@ -9,8 +9,7 @@ JobManager1Service::JobManager1Service(ApplicationManager1Service *parent)
     : m_parent(parent)
 {
     new JobManager1Adaptor{this};
-    if (!registerObjectToDBus(
-            this, DDEApplicationManager1JobManagerObjectPath, getDBusInterface(QMetaType::fromType<JobManager1Adaptor>()))) {
+    if (!registerObjectToDBus(this, DDEApplicationManager1JobManagerObjectPath, JobManagerInterface)) {
         std::terminate();
     }
     qRegisterMetaType<LaunchTask>();

--- a/src/dbus/jobmanager1service.h
+++ b/src/dbus/jobmanager1service.h
@@ -61,7 +61,7 @@ public:
 
         auto *ptr = job.data();
         new JobAdaptor(ptr);
-        if (!registerObjectToDBus(ptr, objectPath, getDBusInterface(QMetaType::fromType<JobAdaptor>()))) {
+        if (!registerObjectToDBus(ptr, objectPath, JobInterface)) {
             qCritical() << "can't register job to dbus.";
             future.cancel();
             return {};

--- a/src/global.h
+++ b/src/global.h
@@ -196,12 +196,24 @@ void unregisterObjectFromDBus(const QString &path);
 
 inline QString getDBusInterface(const QMetaType &meta)
 {
-    const auto *infoObject = meta.metaObject();
-    if (auto infoIndex = infoObject->indexOfClassInfo("D-Bus Interface"); infoIndex != -1) {
-        return infoObject->classInfo(infoIndex).value();
+    auto name = QString{meta.name()};
+    if (name == "ApplicationAdaptor") {
+        return ApplicationInterface;
     }
-    qWarning() << "no interface found.";
-    return {};
+
+    if (name == "InstanceAdaptor") {
+        return InstanceInterface;
+    }
+
+    if (name == "APPObjectManagerAdaptor" or name == "AMObjectManagerAdaptor") {
+        return ObjectManagerInterface;
+    }
+    // const auto *infoObject = meta.metaObject();
+    // if (auto infoIndex = infoObject->indexOfClassInfo("D-Bus Interface"); infoIndex != -1) {
+    //     return infoObject->classInfo(infoIndex).value();
+    // }
+    qWarning() << "couldn't found interface:" << name;
+    return "";
 }
 
 inline ObjectInterfaceMap getChildInterfacesAndPropertiesFromObject(QObject *o)

--- a/src/systemdsignaldispatcher.h
+++ b/src/systemdsignaldispatcher.h
@@ -6,6 +6,7 @@
 #define SYSTEMDSIGNALDISPATCHER_H
 
 #include "global.h"
+#include <QDBusMessage>
 
 class SystemdSignalDispatcher : public QObject
 {
@@ -29,8 +30,13 @@ private:
     explicit SystemdSignalDispatcher(QObject *parent = nullptr)
         : QObject(parent)
     {
+        auto &con = ApplicationManager1DBus::instance().globalDestBus();
+        auto ret = con.call(QDBusMessage::createMethodCall(SystemdService, SystemdObjectPath, SystemdInterfaceName, "Subscribe"));
+        if (ret.type() == QDBusMessage::ErrorMessage) {
+            qFatal("%s", ret.errorMessage().toLocal8Bit().data());
+        }
         if (!connectToSignals()) {
-            std::terminate();
+            qCritical() << "couldn't connect to Systemd signals";
         }
     }
     bool connectToSignals() noexcept;


### PR DESCRIPTION
1. call method metaObject of QMetaType will coredump under Qt 6.4
2. remove `std::terminate()` when AM can't connect to Systemd Signals.
3. call `Subscribe` before connecting to Systemd Signals to guarantee that systemd will send UnitNew and UnitRemoved.