### PR TITLE
chore: relase 0.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager-reborn (0.2.1) unstable; urgency=medium
+
+  * Compatible with Qt 6.2
+
+ -- He YuMing <heyuming@deepin.org>  Wed, 6 Sep 2023 16:52:22 +0800
+
 dde-application-manager-reborn (0.2.0) unstable; urgency=medium
 
   * Release for integration

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -459,7 +459,8 @@ void ApplicationService::removeAllInstance() noexcept
 
 QDBusObjectPath ApplicationService::findInstance(const QString &instanceId) const
 {
-    for (const auto &[path, ptr] : m_Instances.asKeyValueRange()) {
+    for (auto it = m_Instances.constKeyValueBegin(); it != m_Instances.constKeyValueEnd(); ++it) {
+        const auto &[path, ptr] = *it;
         if (ptr->instanceId() == instanceId) {
             return path;
         }

--- a/src/desktopentry.cpp
+++ b/src/desktopentry.cpp
@@ -237,9 +237,11 @@ bool DesktopEntry::checkMainEntryValidation() const noexcept
     auto type = it->find("Type");
     if (type == it->end()) {
         qWarning() << "No Type.";
-        for (const auto &[k, v] : it->asKeyValueRange()) {
+        for (auto tmp = it->constKeyValueBegin(); tmp != it->constKeyValueEnd(); ++tmp) {
+            const auto& [k,v] = *tmp;
             qInfo() << "keyName:" << k;
-            for (const auto &[key, value] : v.asKeyValueRange()) {
+            for (auto valIt = v.constKeyValueBegin() ; valIt != v.constKeyValueEnd(); ++valIt) {
+                const auto &[key, value] = *valIt;
                 qInfo() << key << value;
             }
         }

--- a/src/global.h
+++ b/src/global.h
@@ -459,7 +459,8 @@ ObjectMap dumpDBusObject(const QMap<QDBusObjectPath, QSharedPointer<T>> &map)
 {
     ObjectMap objs;
 
-    for (const auto &[key, value] : map.asKeyValueRange()) {
+    for (auto it = map.constKeyValueBegin(); it != map.constKeyValueEnd(); ++it) {
+        const auto &[key, value] = *it;
         auto interAndProps = getChildInterfacesAndPropertiesFromObject(value.data());
         objs.insert(key, interAndProps);
     }

--- a/src/launchoptions.cpp
+++ b/src/launchoptions.cpp
@@ -11,7 +11,8 @@
 QStringList generateCommand(const QVariantMap &props) noexcept
 {
     std::vector<std::unique_ptr<LaunchOption>> options;
-    for (const auto &[key, value] : props.asKeyValueRange()) {
+    for (auto it = props.constKeyValueBegin(); it!= props.constKeyValueEnd(); ++it) {
+        const auto &[key, value] = *it;
         if (key == setUserLaunchOption::key()) {
             options.push_back(std::make_unique<setUserLaunchOption>(value));
         } else if (key == setEnvLaunchOption::key()) {


### PR DESCRIPTION
Due to QMap::asKeyValueRange not available before Qt 6.4, some method need to refactor.