### PR TITLE
fix: crash when autostart desktop file contains an empty line

### DIFF
--- a/src/lib/keyfile.cpp
+++ b/src/lib/keyfile.cpp
@@ -220,7 +220,7 @@ bool KeyFile::loadFile(const std::string &filePath)
             )
         );
 
-        if (line.front() == '#') {
+        if (line.empty() || line.front() == '#') {
             continue;
         }
 
@@ -231,6 +231,10 @@ bool KeyFile::loadFile(const std::string &filePath)
             ).base(),
             line.end()
         );
+
+        if (line.empty()) {
+            continue;
+        }
 
         if (line.front() == '[') {
             auto rPos = line.find_first_of(']');


### PR DESCRIPTION
Calling line.front() on an empty line is forbidden and crashes the process. Adding checks after erasing spaces from the line.

```
(gdb) bt
 #0  0x00007ffff568e83c in  () at /usr/lib/libc.so.6
 #1  0x00007ffff563e668 in raise () at /usr/lib/libc.so.6
 #2  0x00007ffff56264b8 in abort () at /usr/lib/libc.so.6
 #3  0x00007ffff5add3b2 in std::__glibcxx_assert_fail(char const*, int, char const*, char const*)
     (file=file@entry=0x7ffff5bd7858 "/usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h", line=line@entry=1305, function=function@entry=0x7ffff5bd79d0 "std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::front() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocat"..., condition=condition@entry=0x7ffff5bd3f6e "!empty()") at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/debug.cc:61
 #4  0x00007ffff5b5a124 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::front() (this=<optimized out>) at /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h:1305
 #5  0x00005555555dc011 in KeyFile::loadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
 #6  0x00005555555cd504 in DesktopInfo::DesktopInfo(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
 #7  0x000055555565b64e in StartManager::getAutostartList()::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const ()
 #8  0x000055555565ba51 in StartManager::getAutostartList() ()
 #9  0x0000555555654dd4 in StartManager::StartManager(QObject*) ()
 #10 0x000055555566d5c0 in ApplicationManagerPrivate::ApplicationManagerPrivate(ApplicationManager*) ()
 #11 0x000055555566ec8e in ApplicationManager::ApplicationManager(QObject*) ()
 #12 0x000055555566eba5 in ApplicationManager::instance() ()
 #13 0x00005555556769ce in main ()
```