### PR TITLE
fix: crash when XDG_DATA_DIRS is unset

### DIFF
--- a/src/lib/utils.cpp
+++ b/src/lib/utils.cpp
@@ -76,7 +76,8 @@ std::vector<std::string> getSystemDataDirs()
     std::vector<std::string> systemDir = getSystemDirs("XDG_DATA_DIRS");
 
     if (systemDir.empty()) {
-        systemDir.push_back({"/usr/local/share", "/usr/share"});
+        systemDir.push_back("/usr/local/share");
+        systemDir.push_back("/usr/share");
     }
 
     return systemDir;


### PR DESCRIPTION
std::vector<>::push_back() doesn't accept multiple elements and crashes due to incompatible type being provided. Let's just push twice.