### PR TITLE
fix: can't write environ to storage

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -573,7 +573,7 @@ void ApplicationService::setEnviron(const QString &value) noexcept
     }
 
     auto appId = id();
-    if (!m_environ.isEmpty()) {
+    if (!storagePtr->readApplicationValue(appId, ApplicationPropertiesGroup, Environ).isNull()) {
         if (!storagePtr->updateApplicationValue(appId, ApplicationPropertiesGroup, Environ, value)) {
             sendErrorReply(QDBusError::Failed, "update environ failed.");
             return;

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -34,21 +34,19 @@
 
 void ApplicationService::appendExtraEnvironments(QVariantMap &runtimeOptions) const noexcept
 {
-    QString oldEnv;
-    if (auto it = runtimeOptions.find("env"); it != runtimeOptions.cend()) {
-        oldEnv = it->value<QString>();
-    }
-
+    QStringList envs;
     const QString &env = environ();
-    if (!env.isEmpty()) {
-        //NOTE: prepend this directly may lead some error
-        oldEnv.prepend(env);
+    if (!env.isEmpty())
+        envs.append(env);
+
+    if (auto it = runtimeOptions.find("env"); it != runtimeOptions.cend()) {
+        envs.append(it->value<QString>());
     }
 
     // NOTE: dde-dock need this environment variable for now, maybe we could remove it after we finish refactoring dde-shell.
-    oldEnv.append(QString{"GIO_LAUNCHED_DESKTOP_FILE=%1;"}.arg(m_desktopSource.sourcePath()));
+    envs.append(QString{"GIO_LAUNCHED_DESKTOP_FILE=%1"}.arg(m_desktopSource.sourcePath()));
 
-    runtimeOptions.insert("env", oldEnv);
+    runtimeOptions.insert("env", envs.join(';'));
 }
 
 ApplicationService::ApplicationService(DesktopFile source,


### PR DESCRIPTION
m_environ maybe empty when it is be set more than once.
and the key is already exists in storage.
