### PR TITLE
fix: missing package parsed when ReloadApplicaitons

### DIFF
--- a/src/dbus/applicationmanager1service.h
+++ b/src/dbus/applicationmanager1service.h
@@ -66,6 +66,8 @@ Q_SIGNALS:
     void InterfacesRemoved(const QDBusObjectPath &object_path, const QStringList &interfaces);
     void listChanged();
 
+private Q_SLOTS:
+    void doReloadApplications();
 private:
     std::unique_ptr<Identifier> m_identifier;
     std::weak_ptr<ApplicationManager1Storage> m_storage;


### PR DESCRIPTION
Restart timer to merge directory changed and dpkg hook event. Reload applications when called from dbus.

issue: https://github.com/linuxdeepin/developer-center/issues/7830