### PR TITLE
fix: self start setting failed

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -669,7 +669,7 @@ void ApplicationService::setAutoStart(bool autostart) noexcept
         newEntry = *m_entry;
     }
 
-    newEntry.insert(DesktopFileEntryKey, X_Deepin_GenerateSource, m_autostartSource.m_filePath);
+    newEntry.insert(DesktopFileEntryKey, X_Deepin_GenerateSource, m_desktopSource.sourcePath());
     newEntry.insert(DesktopFileEntryKey, DesktopEntryHidden, !autostart);
 
     setAutostartSource({fileName, newEntry});


### PR DESCRIPTION
incorrect information was set for key:  'X-Deepin-GenerateSource'

Issue: https://github.com/linuxdeepin/developer-center/issues/7637