### PR TITLE
feat: support apps launched directly by systemd

### DIFF
--- a/src/systemdsignaldispatcher.cpp
+++ b/src/systemdsignaldispatcher.cpp
@@ -54,18 +54,10 @@ void SystemdSignalDispatcher::onPropertiesChanged(QString interface, QVariantMap
 
 void SystemdSignalDispatcher::onUnitNew(QString unitName, QDBusObjectPath systemdUnitPath)
 {
-    if (!unitName.startsWith("app-")) {
-        return;
-    }
-
     emit SystemdUnitNew(unitName, systemdUnitPath);
 }
 
 void SystemdSignalDispatcher::onUnitRemoved(QString unitName, QDBusObjectPath systemdUnitPath)
 {
-    if (!unitName.startsWith("app-")) {
-        return;
-    }
-
     emit SystemdUnitRemoved(unitName, systemdUnitPath);
 }


### PR DESCRIPTION
Do not filter out those not launched by application manager. Assume unit name as the app id. When Identify, assume there is only one unique instance.

Log: support apps launched directly by systemd
Related-to: https://github.com/linuxdeepin/developer-center/issues/8088