### PR TITLE
fix: dde-open file failed

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -968,7 +968,7 @@ LaunchTask ApplicationService::unescapeExec(const QString &str, const QStringLis
         execList.remove(location);
         auto it = execList.begin() + location;
         for (const auto &field : fields) {
-            auto tmp = QUrl{field};
+            auto tmp = QUrl::fromUserInput(field);
             if (auto scheme = tmp.scheme(); scheme.startsWith("file") or scheme.isEmpty()) {
                 it = execList.insert(it, tmp.toLocalFile());
             } else {


### PR DESCRIPTION
QUrl("/tmp/xxx.png").toLocalFile() is Empty..

Issue: https://github.com/linuxdeepin/developer-center/issues/8142