### PR TITLE
feat: Add a hook and wrap all applications in the hook script to start

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Homepage: https://github.com/linuxdeepin/dde-application-manager
 Package: dde-application-manager
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Suggests: deepin-deb-fix
 Description:  Application manager for DDE.
   Launch applications by systemd for more caps.
 

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -53,10 +53,26 @@ configure_file(
     hooks.d/1-dockEnv.json
     @ONLY
 )
+configure_file(
+    hooks.d/2-debFix.json.in
+    hooks.d/2-debFix.json
+    @ONLY
+)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hooks.d/1-dockEnv.json
         DESTINATION ${HOOKS_DEST_DIR})
 
 install(FILES ${CMAKE_CURRENT_LIST_DIR}/hooks.d/dockEnv.sh
+        DESTINATION ${AM_LIBEXEC_DIR}
+        PERMISSIONS
+            OWNER_READ OWNER_EXECUTE OWNER_WRITE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hooks.d/2-debFix.json
+        DESTINATION ${HOOKS_DEST_DIR})
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/hooks.d/debFix.sh
         DESTINATION ${AM_LIBEXEC_DIR}
         PERMISSIONS
             OWNER_READ OWNER_EXECUTE OWNER_WRITE

--- a/misc/hooks.d/2-debFix.json.in
+++ b/misc/hooks.d/2-debFix.json.in
@@ -1,0 +1,5 @@
+
+{
+    "Exec": "@CMAKE_INSTALL_PREFIX@/@AM_LIBEXEC_DIR@/debFix.sh",
+    "Args":[]
+}

--- a/misc/hooks.d/debFix.sh
+++ b/misc/hooks.d/debFix.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# This hook script wraps the startup of all applications within this script, 
+# in order to fix the issue of some applications not being able to start without shebang in their startup scripts
+
+firstArg=$1
+
+if [[ -f ${firstArg} ]]; then
+    shebangFound=false
+    while IFS= read -r line; do
+        if [[ "$line" == "#!"* ]]; then
+            shebangFound=true
+            break
+        fi
+    done < "$firstArg"
+
+    if [ "$shebangFound" = false ] && file -b "$firstArg" | grep -q "Python script"; then
+        pythonInterpreter=$(command -v python3 || command -v python)
+        if [ -z "${pythonInterpreter}" ]; then
+            echo "Python interpreter not found."
+            exit 1
+        fi
+        exec ${pythonInterpreter} "$@"
+    fi
+fi
+
+exec "$@"

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -650,7 +650,7 @@ void ApplicationManager1Service::doReloadApplications()
             }
 
             if (destApp != m_applicationList.cend() and apps.contains(destApp.key())) {
-                // Can emit correct remove signal when uninstalling applications patched by deepin-deb-fix
+                // Can emit correct remove signal when uninstalling applications
                 if (ApplicationFilter::tryExecCheck(*(destApp->data()->m_entry))) {
                     qDebug() << info.absolutePath() << "Checked TryExec failed and will be removed";
                     return false;


### PR DESCRIPTION
Add a hook to solve the problem of not being able to start some startup scripts for applications without shebang

Log: 