### PR TITLE
fix: crash when desktop file has "Hidden"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.11) unstable; urgency=medium
+
+  * release 1.2.11
+
+ -- Mike Chen <chenke@deepin.org>  Sat, 11 May 2024 15:28:44 +0800
+
 dde-application-manager (1.2.10) unstable; urgency=medium
 
   * fix: crashed when launching a application contains "%U" 

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -392,7 +392,9 @@ QHash<QSharedPointer<ApplicationService>, QString> ApplicationManager1Service::s
 
         auto shouldLaunch = tmp.value(DesktopFileEntryKey, DesktopEntryHidden).value_or(DesktopEntry::Value{});
         if (!shouldLaunch.isNull() and (shouldLaunch.toString().compare("true", Qt::CaseInsensitive) == 0)) {
-            app->setAutostartSource({desktopFile.sourcePath(), std::move(tmp)});
+            if (app)
+                app->setAutostartSource({desktopFile.sourcePath(), std::move(tmp)});
+
             qInfo() << "shouldn't launch this autoStart item.";
             continue;
         }


### PR DESCRIPTION
xdg 自启动目录下有些desktop文件有 Hidden 字段没有 GenerateSource
导致调用为构造的app(nullptr)

Issue: https://github.com/linuxdeepin/developer-center/issues/8523