### PR TITLE
chore: set apps quit timeout to 3s

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.13) unstable; urgency=medium
+
+  * chore: set apps quit timeout to 3s (https://github.com/linuxdeepin/developer-center/issues/8554)
+
+ -- zsien <quezhiyong@deepin.org>  Wed, 15 May 2024 09:54:55 +0800
+
 dde-application-manager (1.2.12) unstable; urgency=medium
 
   * release 1.2.12

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -20,9 +20,14 @@ set(SYSTEMD_USER_FILE
     ${CMAKE_CURRENT_BINARY_DIR}/systemd/user/org.desktopspec.ApplicationManager1.service
 )
 
+set(SYSTEMD_USER_DROP_IN_FILE
+    ${CMAKE_CURRENT_SOURCE_DIR}/systemd/user/app-DDE-.service.d/override.conf
+)
+
 set(SERVICE_DEST_PATH ${CMAKE_INSTALL_PREFIX}/lib/systemd/user/)
 
 install(FILES ${SYSTEMD_USER_FILE} DESTINATION ${SERVICE_DEST_PATH})
+install(FILES ${SYSTEMD_USER_DROP_IN_FILE} DESTINATION ${SERVICE_DEST_PATH}/app-DDE-.service.d)
 
 # create a symlink to dde-session
 install_symlink(org.desktopspec.ApplicationManager1.service dde-session-initialized.target.wants)

--- a/misc/systemd/user/app-DDE-.service.d/override.conf
+++ b/misc/systemd/user/app-DDE-.service.d/override.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+[Service]
+TimeoutStopSec=3


### PR DESCRIPTION
添加 systemd drop-in 文件，将 app-DDE- 开头的
服务退出超时时间设置为 3s

Issues: linuxdeepin/developer-center#8554