### PR TITLE
fix: open terminal with shortcut for first time crashed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.12) unstable; urgency=medium
+
+  * release 1.2.12
+
+ -- Mike Chen <chenke@deepin.org>  Tue, 14 May 2024 21:00:43 +0800
+
 dde-application-manager (1.2.11) unstable; urgency=medium
 
   * release 1.2.11

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -695,6 +695,11 @@ QStringList ApplicationService::mimeTypes() const noexcept
         return desktopFilePath.startsWith(info.directory());
     });
 
+    if (cache == cacheList.cend()) {
+        qWarning() << "error occurred when get mimeTypes for" << desktopFilePath;
+        return ret;
+    }
+
     const auto &info = cache->cacheInfo();
     if (info) {
         ret.append(info->queryTypes(id()));


### PR DESCRIPTION
reutrn {} at end of std::vector<MimeInfo>

Issue: https://github.com/linuxdeepin/developer-center/issues/8598