### PR TITLE
feat: add app extra env config

### DIFF
--- a/api/dbus/org.desktopspec.ApplicationManager1.Application.xml
+++ b/api/dbus/org.desktopspec.ApplicationManager1.Application.xml
@@ -138,10 +138,13 @@
                        1. `uid` (type u):
                           The user id as who is that application will be run.
                           This option might request a polikit authentication.
-                       2. `env` (type s):
+                       2. `env` (type as):
                           passing some specific environment variables to Launch
-                          this application, eg. 'LANG=en_US;PATH=xxx:yyy;'
-                       3. `path` (type s):
+                          this application without them, eg. '[LANG=en_US, PATH=xxx:yyy]'
+                       3. `unsetEnv` (type as):
+                          passed environment variables will be ignored when
+                          launching this application, eg. '[LANG, PATH]'
+                       4. `path` (type s):
                           set this application's working directory, please pass
                           absolute directory path.
                        NOTE:

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -97,5 +97,7 @@ set(DCONFIG_FILES
 install(FILES ${DCONFIG_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/dsg/configs/dde-application-manager)
 
 dtk_add_config_meta_files(APPID ${APPLICATION_SERVICEID}
-    FILES ${CMAKE_CURRENT_LIST_DIR}/dsg/configs/dde-application-manager/org.deepin.dde.am.json
+    FILES
+    ${CMAKE_CURRENT_LIST_DIR}/dsg/configs/dde-application-manager/org.deepin.dde.am.json
+    ${CMAKE_CURRENT_LIST_DIR}/dsg/configs/dde-application-manager/org.deepin.dde.application-manager.json
 )

--- a/misc/dsg/configs/dde-application-manager/org.deepin.dde.application-manager.json
+++ b/misc/dsg/configs/dde-application-manager/org.deepin.dde.application-manager.json
@@ -1,0 +1,26 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "appExtraEnvironments": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "Launching app with extra environments",
+            "name[zh_CN]": "启动应用时附加额外环境变量",
+            "description": "Launching app with extra environments",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "appEnvironmentsBlacklist": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "Ignore blacklisted environment variables before launching app",
+            "name[zh_CN]": "启动应用时取消某些环境变量",
+            "description": "Ignore blacklisted environment variables before launching app",
+            "permissions": "readwrite",
+            "visibility": "public"
+        }
+    }
+}

--- a/src/constant.h
+++ b/src/constant.h
@@ -65,4 +65,8 @@ constexpr auto ApplicationManagerHookDir = u8"/deepin/dde-application-manager/ho
 
 constexpr auto ApplicationManagerToolsConfig = u8"org.deepin.dde.am";
 
+constexpr auto ApplicationManagerConfig = u8"org.deepin.dde.application-manager";
+constexpr auto AppExtraEnvironments = u8"appExtraEnvironments";
+constexpr auto AppEnvironmentsBlacklist = u8"appEnvironmentsBlacklist";
+
 #endif

--- a/src/dbus/CMakeLists.txt
+++ b/src/dbus/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::DBus
     Qt${QT_VERSION_MAJOR}::Concurrent
+    Dtk6::Core
 )
 
 target_include_directories(

--- a/src/launchoptions.cpp
+++ b/src/launchoptions.cpp
@@ -17,6 +17,8 @@ QStringList generateCommand(const QVariantMap &props) noexcept
             options.emplace_back(std::make_unique<setUserLaunchOption>(value));
         } else if (key == setEnvLaunchOption::key()) {
             options.emplace_back(std::make_unique<setEnvLaunchOption>(value));
+        } else if (key == unsetEnvLaunchOption::key()) {
+            options.emplace_back(std::make_unique<unsetEnvLaunchOption>(value));
         } else if (key == hookLaunchOption::key()) {
             options.emplace_back(std::make_unique<hookLaunchOption>(value));
         } else if (key == setWorkingPathLaunchOption::key()) {
@@ -100,16 +102,6 @@ QStringList splitLaunchOption::generateCommandLine() const noexcept
     return QStringList{m_val.toString()};
 }
 
-QStringList setEnvLaunchOption::generateCommandLine() const noexcept
-{
-    auto str = m_val.toString();
-    if (str.isEmpty()) {
-        return {};
-    }
-
-    return QStringList{QString{"--Environment=%1"}.arg(str)};
-}
-
 QStringList setWorkingPathLaunchOption::generateCommandLine() const noexcept
 {
     auto str = m_val.toString();
@@ -120,13 +112,18 @@ QStringList setWorkingPathLaunchOption::generateCommandLine() const noexcept
     return QStringList{QString{"--WorkingDirectory=%1"}.arg(str)};
 }
 
-QStringList builtInSearchExecOption::generateCommandLine() const noexcept
+QStringList StringListLaunchOption::generateCommandLine() const noexcept
 {
     auto list = m_val.toStringList();
     if (list.isEmpty()) {
         return {};
     }
 
-    auto content = list.join(';');
-    return QStringList{QString{"--ExecSearchPath=%1"}.arg(content)};
+    QStringList ret;
+    const QString ok = optionKey();
+    for (const auto &ov : list) {
+        ret << QString{"%1=%2"}.arg(ok).arg(ov);
+    }
+
+    return ret;
 }

--- a/src/launchoptions.h
+++ b/src/launchoptions.h
@@ -27,6 +27,14 @@ protected:
     LaunchOption() = default;
 };
 
+struct StringListLaunchOption : public LaunchOption
+{
+    using LaunchOption::LaunchOption;
+    [[nodiscard]] QStringList generateCommandLine() const noexcept override;
+protected:
+    [[nodiscard]] virtual const QString optionKey() const noexcept = 0;
+};
+
 struct setUserLaunchOption : public LaunchOption
 {
     using LaunchOption::LaunchOption;
@@ -43,9 +51,9 @@ struct setUserLaunchOption : public LaunchOption
     [[nodiscard]] QStringList generateCommandLine() const noexcept override;
 };
 
-struct setEnvLaunchOption : public LaunchOption
+struct setEnvLaunchOption : public StringListLaunchOption
 {
-    using LaunchOption::LaunchOption;
+    using StringListLaunchOption::StringListLaunchOption;
     [[nodiscard]] const QString &type() const noexcept override
     {
         static QString tp{systemdOption};
@@ -56,7 +64,10 @@ struct setEnvLaunchOption : public LaunchOption
         static QString env{"env"};
         return env;
     }
-    [[nodiscard]] QStringList generateCommandLine() const noexcept override;
+protected:
+    [[nodiscard]] virtual const QString optionKey() const noexcept {
+        return QString("--Environment");
+    }
 };
 
 struct splitLaunchOption : public LaunchOption
@@ -110,9 +121,9 @@ struct setWorkingPathLaunchOption : public LaunchOption
     [[nodiscard]] QStringList generateCommandLine() const noexcept override;
 };
 
-struct builtInSearchExecOption : public LaunchOption
+struct builtInSearchExecOption : public StringListLaunchOption
 {
-    using LaunchOption::LaunchOption;
+    using StringListLaunchOption::StringListLaunchOption;
     [[nodiscard]] const QString &type() const noexcept override
     {
         static QString tp{systemdOption};
@@ -123,7 +134,29 @@ struct builtInSearchExecOption : public LaunchOption
         static QString key{"_builtIn_searchExec"};
         return key;
     }
-    [[nodiscard]] QStringList generateCommandLine() const noexcept override;
+protected:
+    [[nodiscard]] virtual const QString optionKey() const noexcept {
+        return QString("--ExecSearchPath");
+    }
+};
+
+struct unsetEnvLaunchOption : public StringListLaunchOption
+{
+    using StringListLaunchOption::StringListLaunchOption;
+    [[nodiscard]] const QString &type() const noexcept override
+    {
+        static QString tp{systemdOption};
+        return tp;
+    }
+    [[nodiscard]] static const QString &key() noexcept
+    {
+        static QString env{"unsetEnv"};
+        return env;
+    }
+protected:
+    [[nodiscard]] virtual const QString optionKey() const noexcept {
+        return QString("--UnsetEnvironment");
+    }
 };
 
 QStringList generateCommand(const QVariantMap &props) noexcept;


### PR DESCRIPTION
to fix #8667 you can
- subpath:"/FoxitReader" appExtraEnvironments : "QT_QPA_PLATFORM=xcb"
- subpath:"/FoxitReader" appEnvironmentsBlacklist : "QT_QPA_PLATFORM"
    
```
# override QT_QPA_PLATFORM to xcb
dde-dconfig set -a org.deepin.dde.application-manager -r org.deepin.dde.application-manager -k appExtraEnvironments -s "/FoxitReader" -v "[\"QT_QPA_PLATFORM=xcb\"]"
# or unset QT_QPA_PLATFORM
dde-dconfig set -a org.deepin.dde.application-manager -r org.deepin.dde.application-manager -k appEnvironmentsBlacklist -s "/FoxitReader" -v "[\"QT_QPA_PLATFORM\"]"
```
    
Issue: https://github.com/linuxdeepin/developer-center/issues/8667