### PR TITLE
fix: convert file:// to local path

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.27) unstable; urgency=medium
+
+  * fix: convert file:// to local path
+
+ -- heyuming <heyuming@deepin.org>  Thu, 10 Apr 2025 16:52:52 +0800
+
 dde-application-manager (1.2.26) unstable; urgency=medium
 
   * fix: abnormal splitting of parameters enclosed in quotation marks in Exec
@@ -96,7 +102,7 @@ dde-application-manager (1.2.11) unstable; urgency=medium
 
 dde-application-manager (1.2.10) unstable; urgency=medium
 
-  * fix: crashed when launching a application contains "%U" 
+  * fix: crashed when launching a application contains "%U"
   * fix: revert "crashed when removing a invalid index"
 
  -- Wang Fei <wangfei@deepin.org>  Fri, 10 May 2024 15:18:39 +0800

--- a/src/dbus/jobmanager1service.h
+++ b/src/dbus/jobmanager1service.h
@@ -33,7 +33,7 @@ struct LaunchTask
     QString LaunchBin;
     QStringList command;
     QVariantList Resources;
-    bool singleInstance{false};
+    bool local{false};
     int argNum{-1};
     int fieldLocation{-1};
 };


### PR DESCRIPTION
passing local path to application instead of url when desktop Exec specify %F or %f.

other change:
- respect the original url, passing it to application directly
- correct the application command generating process

## Summary by Sourcery

Improve handling of file URLs and local paths when launching applications through desktop entry files

Bug Fixes:
- Fix the processing of file URLs and local paths when launching applications with %F, %f, %U, and %u desktop entry field codes

Enhancements:
- Enhance URL and file path handling to convert file:// URLs to local paths
- Improve command generation process for application launches
- Respect original URL formats when passing to applications