### PR TITLE
revert the change that validate and remove broken desktop file symlinks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.28) unstable; urgency=medium
+
+  * revert the change that validate and remove broken desktop file symlinks
+
+ -- Wang Zichong <wangzichong@deepin.org>  Thu, 17 Apr 2025 17:27:00 +0800
+
 dde-application-manager (1.2.27) unstable; urgency=medium
 
   * fix: convert file:// to local path

--- a/src/dbus/applicationmanager1service.h
+++ b/src/dbus/applicationmanager1service.h
@@ -46,7 +46,6 @@ public:
     [[nodiscard]] QHash<QDBusObjectPath, QSharedPointer<ApplicationService>>
     findApplicationsByIds(const QStringList &appIds) const noexcept;
     void updateApplication(const QSharedPointer<ApplicationService> &destApp, DesktopFile desktopFile) noexcept;
-    void autoRemoveFromDesktop() noexcept;
 
     [[nodiscard]] const auto &Applications() const noexcept { return m_applicationList; }
     [[nodiscard]] JobManager1Service &jobManager() noexcept { return *m_jobManager; }


### PR DESCRIPTION
## Summary by Sourcery

Revert the implementation of automatic desktop file symlink validation and removal

Bug Fixes:
- Remove the code that automatically checks and deletes broken desktop file symlinks from the desktop directory

Chores:
- Removed related header imports and method declaration for desktop file symlink removal functionality