### PR TITLE
fix: avoid accidently cleanup newly installed hidden apps

### DIFF
--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -555,7 +555,8 @@ void ApplicationManager1Service::removeOneApplication(const QString &appId) noex
             }
         }
         unregisterObjectFromDBus(objectPath.path());
-        m_applicationList.remove(appId);
+        std::ignore = it->data()->RemoveFromDesktop();
+        m_applicationList.erase(it);
 
         emit listChanged();
     }

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -188,7 +188,6 @@ ApplicationService::ApplicationService(DesktopFile source,
 ApplicationService::~ApplicationService()
 {
     detachAllInstance();
-    autoRemoveFromDesktop();
 }
 
 QSharedPointer<ApplicationService> ApplicationService::createApplicationService(
@@ -1265,28 +1264,6 @@ void ApplicationService::unescapeEens(QVariantMap &options) noexcept
     }
 
     options.insert("env", result);
-}
-
-void ApplicationService::autoRemoveFromDesktop() const noexcept
-{
-    auto dir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-    if (dir.isEmpty()) {
-        return;
-    }
-
-    QFileInfo desktopFile{QDir{dir}.filePath(m_desktopSource.desktopId() + ".desktop")};
-
-    if (!desktopFile.isSymbolicLink()) {
-        qDebug() << desktopFile.filePath() << " is not symbolicLink";
-        return;
-    }
-
-    QFile file{desktopFile.filePath()};
-    auto success = file.remove();
-    if (!success) {
-        qWarning() << "remove desktop file failed:" << file.errorString();
-        return;
-    }
 }
 
 QVariant ApplicationService::findEntryValue(const QString &group,

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -146,7 +146,6 @@ public:
     [[nodiscard]] LaunchTask unescapeExec(const QString &str, QStringList fields) noexcept;
     [[nodiscard]] static std::optional<QStringList> unescapeExecArgs(const QString &str) noexcept;
     void unescapeEens(QVariantMap &options) noexcept;
-    void autoRemoveFromDesktop() const noexcept;
 
 public Q_SLOTS:
     // NOTE: 'realExec' only for internal implementation


### PR DESCRIPTION
避免新安装但其 desktop 声明为隐藏的应用的桌面快捷方式在应用安装完成的瞬间被错误清理.

## Summary by Sourcery

Modify desktop shortcut removal logic to prevent accidentally removing newly installed hidden applications' desktop files

Bug Fixes:
- Prevent unintended removal of desktop shortcuts for newly installed hidden applications

Enhancements:
- Refactor desktop file removal method to be more robust
- Add optional symlink-only removal parameter