### PR TITLE
fix: when reboot,none-autostart app is incorrectly set to a auto-start icon

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -770,10 +770,6 @@ bool ApplicationService::isAutoStart() const noexcept
         return false;
     }
 
-    if (m_autostartSource.m_filePath == m_desktopSource.sourcePath()) {
-        return true;
-    }
-
     auto appId = id();
     auto dirs = getAutoStartDirs();
     QString destDesktopFile;


### PR DESCRIPTION
as title.

PMS-BUG-281483

## Summary by Sourcery

Bug Fixes:
- Remove condition that treated matching desktop and autostart file paths as an indication of auto-start.