### PR TITLE
feat: Add GenericName handling to DesktopFileGenerator

### DIFF
--- a/src/desktopfilegenerator.cpp
+++ b/src/desktopfilegenerator.cpp
@@ -45,6 +45,17 @@ int DesktopFileGenerator::processMainGroupLocaleEntry(DesktopEntry::container_ty
         return 1;
     }
 
+    if (key == "GenericName") {
+        const auto &genericNameMap = qdbus_cast<QStringMap>(value);
+        if (genericNameMap.isEmpty()) {
+            qDebug() << "GenericName's type mismatch:" << genericNameMap;
+            return -1;
+        }
+
+        mainEntry->insert("GenericName", QVariant::fromValue(genericNameMap));
+        return 1;
+    }
+
     if (key == "Icon") {
         const auto &iconMap = qdbus_cast<QStringMap>(value);
         if (auto icon = iconMap.constFind(DesktopFileDefaultKeyLocale); icon != iconMap.cend() and !icon->isEmpty()) {


### PR DESCRIPTION
Implement processing for the "GenericName" key in the main group locale entry of desktop files. This ensures that the GenericName field is correctly parsed and inserted into the main entry, improving compatibility with desktop file standards.

pms: BUG-300903