### PR TITLE
fix: return value for empty GenericName map in desktop file generator

### DIFF
--- a/src/desktopfilegenerator.cpp
+++ b/src/desktopfilegenerator.cpp
@@ -49,7 +49,7 @@ int DesktopFileGenerator::processMainGroupLocaleEntry(DesktopEntry::container_ty
         const auto &genericNameMap = qdbus_cast<QStringMap>(value);
         if (genericNameMap.isEmpty()) {
             qDebug() << "GenericName's type mismatch:" << genericNameMap;
-            return -1;
+            return 1;
         }
 
         mainEntry->insert("GenericName", QVariant::fromValue(genericNameMap));


### PR DESCRIPTION
Change the return value from `-1` to `1` when the GenericName map is empty to align with error handling conventions and improve consistency in the codebase.

log: as tile

## Summary by Sourcery

Bug Fixes:
- Return 1 instead of -1 for an empty GenericName map in the desktop file generator