### PR TITLE
fix: Fix unit name error when launch with parameters

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -420,7 +420,7 @@ ApplicationService::Launch(const QString &action, const QStringList &fields, con
             }
 
             newCommands.push_front(QString{"--SourcePath=%1"}.arg(m_desktopSource.sourcePath()));
-            newCommands.push_front(QString{R"(--unitName=DDE-%1@%2.service)"}.arg(this->id(), instanceRandomUUID));
+            newCommands.push_front(QString{R"(--unitName=app-DDE-%1@%2.service)"}.arg(escapeApplicationId(this->id()), instanceRandomUUID));
 
             QProcess process;
             qDebug().noquote() << "launcher :" << m_launcher << "run with commands:" << newCommands;


### PR DESCRIPTION
Fix inconsistent unit name generation in Launch method where one code path was missing escapeApplicationId() call, causing application IDs with special characters (like deepin-editor) to not be properly escaped, leading to instance creation failures.

pms: BUG-315995
pms: BUG-281765

## Summary by Sourcery

Bug Fixes:
- Escape application IDs in systemd unit name generation to prevent launch failures with special characters