### PR TITLE
fix: spaces in desktop id can cause app failed to launch

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -34,6 +34,8 @@
 #include <wordexp.h>
 #include <DConfig>
 
+using namespace Qt::Literals::StringLiterals;
+
 static inline void appendEnvs(const QVariant &var, QStringList &envs)
 {
     if (var.canConvert<QStringList>()) {
@@ -1248,6 +1250,10 @@ void ApplicationService::unescapeEens(QVariantMap &options) noexcept
     QStringList result;
     auto envs = options["env"];
     for (const QString &var : envs.toStringList()) {
+        if (var.startsWith(u"DSG_APP_ID="_s)) {
+            result << var;
+            continue;
+        }
         wordexp_t p;
         if (wordexp(var.toStdString().c_str(), &p, 0) == 0) {
             for (size_t i = 0; i < p.we_wordc; i++) {


### PR DESCRIPTION
当前 unescapeEens() 中会不恰当的将包含空格的环境变量展开，可能是为
兼容模式进行的处理。这个行为会导致后续尝试运行应用时的行为异常。

本提交暂时将 `DSG_APP_ID` 环境变量单独跳过（原样传递），以修复包含
空格的 desktop id 的应用无法被正常启动的问题。后续应当明细这个
unescapeEens() 的实际目的和需求，并调整这个地方的实现。

Resolve: https://github.com/linuxdeepin/developer-center/issues/11495

## Summary by Sourcery

Bug Fixes:
- Skip wordexp unescaping for DSG_APP_ID in unescapeEens to maintain spaces in desktop IDs and allow affected apps to start