### PR TITLE
chore: bump version to 1.2.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.31) unstable; urgency=medium
+
+  * fix: spaces in desktop id can cause app failed to launch
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 19 Jun 2025 10:12:23 +0800
+
 dde-application-manager (1.2.30) unstable; urgency=medium
 
   * fix: Fix unit name error when launch with parameters


### PR DESCRIPTION
update changelog to 1.2.31

## Summary by Sourcery

Build:
- Bump Debian changelog entry to version 1.2.31.