### PR TITLE
fix: When opening an app and delaying an operation, the mouse does not load transition animations.

### DIFF
--- a/api/dbus/org.desktopspec.ApplicationManager1.Application.xml
+++ b/api/dbus/org.desktopspec.ApplicationManager1.Application.xml
@@ -75,6 +75,13 @@
                 value="Indicate this application should launch by terminal or not."
             />
         </property>
+        
+        <property name="StartupNotify" type="b" access="read">
+            <annotation
+                name="org.freedesktop.DBus.Description"
+                value="Indicate this application should launch with startup notification or not."
+            />
+        </property>
 
         <property name="Environ" type="s" access="readwrite">
             <annotation

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -674,6 +674,15 @@ bool ApplicationService::terminal() const noexcept
     return false;
 }
 
+bool ApplicationService::startupNotify() const noexcept
+{
+    auto val = findEntryValue(DesktopFileEntryKey, "StartupNotify", EntryValueType::String);
+    if (!val.isNull()) {
+        return val.toBool();
+    }
+    return false;
+}
+
 QString ApplicationService::startupWMClass() const noexcept
 {
     auto value = findEntryValue(DesktopFileEntryKey, "StartupWMClass", EntryValueType::String);
@@ -1015,6 +1024,7 @@ void ApplicationService::resetEntry(DesktopEntry *newEntry) noexcept
     emit xDeepinCreatedByChanged();
     emit execsChanged();
     emit xCreatedByChanged();
+    emit startupNotifyChanged();
 }
 
 std::optional<QStringList> ApplicationService::unescapeExecArgs(const QString &str) noexcept

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -84,6 +84,9 @@ public:
     [[nodiscard]] bool isAutoStart() const noexcept;
     void setAutoStart(bool autostart) noexcept;
 
+    Q_PROPERTY(bool StartupNotify READ startupNotify NOTIFY startupNotifyChanged)
+    [[nodiscard]] bool startupNotify() const noexcept;
+
     Q_PROPERTY(QStringList MimeTypes READ mimeTypes WRITE setMimeTypes)
     [[nodiscard]] QStringList mimeTypes() const noexcept;
     void setMimeTypes(const QStringList &value) noexcept;
@@ -180,6 +183,7 @@ Q_SIGNALS:
     void xDeepinCreatedByChanged();
     void execsChanged();
     void xCreatedByChanged();
+    void startupNotifyChanged();
 
 private:
     friend class ApplicationManager1Service;


### PR DESCRIPTION
目前AM给出了StartuoNotify的属性，需要窗管那边进行处理此属性，从而处理鼠标指针。

pms:BUG-275547

## Summary by Sourcery

Expose and implement a new StartupNotify property in ApplicationService to allow the window manager to handle startup notification flags (enabling proper pointer animations).

New Features:
- Add startupNotify() getter and Q_PROPERTY with notification signal to ApplicationService
- Implement startupNotifyChanged emission when resetting an application entry
- Update D-Bus interface XML to include the StartupNotify boolean property