### PR TITLE
fix: add hardening flags to Debian build rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,10 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 export QT_SELECT = qt6
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 %:
 	dh $@ --buildsystem=cmake


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for security
2. Included compiler warning flags (-Wall) for C/C++ builds
3. Added linker security flags (RELRO, NOW, noexecstack) for binary hardening
4. Set -E flag for symbol export control
5. These changes improve security by enabling standard Debian hardening measures

fix: 在 Debian 构建规则中添加加固标志

1. 添加 DEB_BUILD_MAINT_OPTIONS 并设置 hardening=+all 以提高安全性
2. 包含 C/C++ 编译器的警告标志 (-Wall)
3. 添加链接器安全标志 (RELRO, NOW, noexecstack) 用于二进制加固
4. 设置 -E 标志用于符号导出控制
5. 这些变更通过启用标准的 Debian 加固措施来提高安全性

## Summary by Sourcery

Build:
- Enable Debian hardening by setting DEB_BUILD_MAINT_OPTIONS=hardening=+all, adding -Wall warnings, linker security flags (RELRO, NOW, noexecstack), and the -E symbol export control