### PR TITLE
feat: update dde-am tool

### DIFF
--- a/apps/dde-am/src/launcher.cpp
+++ b/apps/dde-am/src/launcher.cpp
@@ -88,6 +88,11 @@ void Launcher::setLaunchedType(LaunchedType type)
     m_launchedType = type;
 }
 
+void Launcher::setEnvironmentVariables(const QStringList &envVars)
+{
+    m_environmentVariables = envVars;
+}
+
 DExpected<void> Launcher::run()
 {
     if (auto value = launch(); !value)
@@ -105,10 +110,17 @@ DExpected<void> Launcher::launch()
     auto con = QDBusConnection::sessionBus();
     auto msg = QDBusMessage::createMethodCall(
         DDEApplicationManager1ServiceName, m_path, ApplicationInterface, "Launch");
+    
+    // Build options map
+    QVariantMap options;
+    if (!m_environmentVariables.isEmpty()) {
+        options["env"] = QVariant::fromValue(m_environmentVariables);
+    }
+    
     const QList<QVariant> arguments {
         m_action,
         QStringList{},
-        QVariantMap{}
+        options
     };
     msg.setArguments(arguments);
     auto reply = con.call(msg);

--- a/apps/dde-am/src/launcher.h
+++ b/apps/dde-am/src/launcher.h
@@ -16,6 +16,7 @@ public:
     void setPath(const QString &path);
     void setAction(const QString &action);
     void setLaunchedType(LaunchedType type);
+    void setEnvironmentVariables(const QStringList &envVars);
     Dtk::Core::DExpected<void> run();
 
     static Dtk::Core::DExpected<QStringList> appIds();
@@ -27,4 +28,5 @@ private:
     QString m_path;
     QString m_action;
     LaunchedType m_launchedType = Unknown;
+    QStringList m_environmentVariables;
 };

--- a/apps/dde-am/src/main.cpp
+++ b/apps/dde-am/src/main.cpp
@@ -5,9 +5,37 @@
 #include <QCoreApplication>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
+#include <QFileInfo>
+#include <QUrl>
 
 #include "launcher.h"
 #include "global.h"
+#include <DUtil>
+
+DCORE_USE_NAMESPACE
+
+QString getAppIdFromInput(const QString &input)
+{
+    // Use QUrl::fromUserInput to handle both URIs and file paths
+    // 优先直接用 DUtil::getAppIdFromAbsolutePath 判断
+    QString appId = DUtil::getAppIdFromAbsolutePath(input);
+    if (!appId.isEmpty()) {
+        return appId;
+    }
+    // 如果失败，再尝试解析为本地文件路径
+    QUrl url = QUrl::fromUserInput(input);
+    if (!url.isLocalFile()) {
+        return {};
+    }
+    QString path = url.toLocalFile();
+    // fallback: 仅当文件存在且为.desktop时才用basename
+    if (path.endsWith(".desktop") && QFileInfo::exists(path)) {
+        QFileInfo fileInfo(path);
+        appId = fileInfo.completeBaseName();
+        return appId;
+    }
+    return {};
+}
 
 int main(int argc, char *argv[])
 {
@@ -22,8 +50,14 @@ int main(int argc, char *argv[])
     QCommandLineOption launchedByUserOption("by-user",
                                             "Launched by user, it's useful for counting launched times.");
     parser.addOption(launchedByUserOption);
-    parser.addPositionalArgument("appId", "Application's ID.");
-    parser.addPositionalArgument("action", "Name of the action identifiers for the application, optionally.");
+    QCommandLineOption actionOption(QStringList() << "a" << "action",
+                                   "Specify action identifier for the application", "action");
+    parser.addOption(actionOption);
+    QCommandLineOption envOption(QStringList() << "e" << "env",
+                                "Set environment variable, format: NAME=VALUE (can be used multiple times)", "env");
+    parser.addOption(envOption);
+    
+    parser.addPositionalArgument("appId", "Application's ID, .desktop file path, or URI (e.g.: file:///path/to/app.desktop).");;
 
     parser.process(app);
     if (parser.isSet(listOption)) {
@@ -38,21 +72,56 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    QString appId;
+    QString action;
+    QStringList envVars;
+    
+    // Handle environment variables - prioritize -e/--env option
+    if (parser.isSet(envOption)) {
+        envVars.append(parser.values(envOption));
+    }
+    
     auto arguments = parser.positionalArguments();
-    if (arguments.size() < 1)
+    QString inputArg;
+    if (!arguments.isEmpty()) {
+        inputArg = arguments.takeFirst();
+        appId = getAppIdFromInput(inputArg);
+        // 支持 action 作为第二个位置参数
+        if (!arguments.isEmpty()) {
+            action = arguments.takeFirst();
+        }
+    } else {
         parser.showHelp();
+    }
+
+    // Handle action - prioritize --action option 
+    if (parser.isSet(actionOption)) {
+        action = parser.value(actionOption);
+    }
 
     Launcher launcher;
     if (parser.isSet(launchedByUserOption))
         launcher.setLaunchedType(Launcher::ByUser);
 
-    const auto pos1 = arguments.takeFirst();
-    QString appPath = pos1.startsWith("/") ? pos1 :
-                                             QString("%1/%2").arg(DDEApplicationManager1ObjectPath, escapeToObjectPath(pos1));
+    QString appPath;
+    if (!appId.isEmpty()) {
+        // 解析出 appId，说明输入是 appId 或 desktop 文件
+        appPath = QString("%1/%2").arg(DDEApplicationManager1ObjectPath, escapeToObjectPath(appId));
+    } else if (!inputArg.isEmpty() && !inputArg.startsWith("/")) {
+        // 既不是绝对路径，也不是 desktop 文件等，视为 appId
+        appPath = QString("%1/%2").arg(DDEApplicationManager1ObjectPath, escapeToObjectPath(inputArg));
+    } else {
+        // 绝对路径或特殊用法
+        appPath = inputArg;
+    }
     launcher.setPath(appPath);
-    if (arguments.size() >= 1) {
-        const auto action = arguments.takeFirst();
+    
+    if (!action.isEmpty()) {
         launcher.setAction(action);
+    }
+    
+    if (!envVars.isEmpty()) {
+        launcher.setEnvironmentVariables(envVars);
     }
 
     auto ret = launcher.run();

--- a/debian/dde-application-manager.install
+++ b/debian/dde-application-manager.install
@@ -5,3 +5,4 @@ usr/libexec/*
 usr/share/dbus-1/*
 usr/share/dsg/*
 usr/share/deepin/dde-application-manager/hooks.d/*
+usr/share/bash-completion/completions/*

--- a/docs/dde-am-usage.md
+++ b/docs/dde-am-usage.md
@@ -1,0 +1,179 @@
+# dde-am Usage Guide
+
+`dde-am` is a command-line tool for launching applications via the ApplicationManager D-Bus interface. It features unified input handling with automatic format detection, supporting app IDs, desktop file paths, and file URIs without requiring specific options.
+
+## Basic Usage
+
+### 1. Launch app using app ID
+
+```bash
+dde-am dde-calendar
+```
+
+### 2. Launch app using desktop file path
+
+```bash
+dde-am /usr/share/applications/dde-calendar.desktop
+dde-am ~/.local/share/applications/my-app.desktop
+```
+
+### 3. Launch app using file URI
+
+```bash
+dde-am file:///usr/share/applications/dde-calendar.desktop
+dde-am "file:///home/user/Desktop/Clash Verge.desktop"
+```
+
+### 4. Launch app with environment variables (recommended)
+
+```bash
+dde-am -e "DEBUG=1" dde-calendar
+
+# Multiple environment variables
+dde-am -e "DEBUG=1" -e "LANG=en_US.UTF-8" -e "PATH=/custom/path" dde-file-manager
+```
+
+
+### 5. Launch app with action
+
+```bash
+dde-am --action new-window dde-file-manager
+dde-am -a new-window /path/to/app.desktop
+dde-am deepin-terminal quake-mode
+```
+
+### 6. Launch app with user tracking
+
+```bash
+dde-am --by-user dde-calendar
+```
+
+### 7. List all available app IDs
+
+```bash
+dde-am --list
+```
+
+## Command Line Options
+
+- `-a, --action <action>`: Specify action identifier for the application
+- `-e, --env <env>`: Set environment variable, format: NAME=VALUE (can be used multiple times)
+- `--by-user`: Mark as launched by user (useful for counting launched times)
+- `--list`: List all available app IDs
+- `--help`: Show help information
+
+## Features
+
+### Environment Variable Support
+
+The tool now supports passing environment variables to launched applications using the D-Bus interface's `env` option.
+
+### Unified Input Support
+
+- **Automatic format detection**: Uses `QUrl::fromUserInput()` to intelligently handle various input formats
+- **Desktop file paths**: Supports absolute paths to .desktop files
+- **File URIs**: Supports file:// URIs and automatically converts them to local paths
+- **App IDs**: Traditional app ID format remains fully supported
+- **Fallback mechanism**: For .desktop files in non-standard locations, uses filename without .desktop suffix
+
+### Backward Compatibility
+
+All existing functionality is preserved, and the tool maintains backward compatibility with previous versions.
+
+## Input Format Examples
+
+The tool now supports unified input handling - you can use any of these formats without specific options:
+
+### App ID Format
+
+```bash
+dde-am dde-calendar
+dde-am org.gnome.Calculator
+```
+
+### Desktop File Path Format
+
+```bash
+dde-am /usr/share/applications/dde-calendar.desktop
+dde-am ~/.local/share/applications/custom-app.desktop
+dde-am "/home/user/Desktop/My App.desktop"
+```
+
+### File URI Format
+
+```bash
+dde-am file:///usr/share/applications/dde-calendar.desktop
+dde-am "file:///home/user/Desktop/Custom App.desktop"
+```
+
+### Combined with Other Options
+
+```bash
+# With action
+dde-am file:///usr/share/applications/dde-file-manager.desktop --action new-window
+
+# With environment variables
+dde-am /usr/share/applications/gimp.desktop -e "LANG=en_US" -e "DEBUG=1"
+
+# All together
+dde-am ~/.local/share/applications/my-app.desktop --action open-file -e "VAR=value" --by-user
+```
+
+## Examples
+
+### Launch Calculator with Debug Output
+
+```bash
+dde-am -e "DEBUG=1" dde-calculator
+```
+
+### Launch Browser with Custom Language
+
+```bash
+dde-am -e "LANG=en_US.UTF-8" firefox
+```
+
+### Launch App from Desktop File
+
+```bash
+dde-am ~/.local/share/applications/my-app.desktop
+dde-am /usr/share/applications/gimp.desktop
+```
+
+### Launch App from URI with Environment Variable
+
+```bash
+dde-am file:///usr/share/applications/gimp.desktop -e "DISPLAY=:1"
+dde-am "file:///home/user/Desktop/Custom App.desktop" -e "DEBUG=1"
+```
+
+### Launch App with Action
+
+```bash
+# Using --action option
+dde-am --action new-window dde-file-manager
+dde-am -a compose thunderbird
+
+# Using positional argument
+dde-am dde-text-editor new-document
+```
+
+### Launch App with Multiple Environment Variables
+
+```bash
+# Set multiple environment variables for development
+dde-am -e "DEBUG=1" -e "VERBOSE=1" -e "LOG_LEVEL=trace" my-dev-app
+
+# Launch with custom locale and display settings
+dde-am -e "LANG=zh_CN.UTF-8" -e "DISPLAY=:0" -e "GTK_THEME=Adwaita" dde-file-manager
+```
+
+## Notes
+
+- App IDs are typically derived from .desktop filenames
+- Environment variables must use the format "NAME=VALUE"
+- The `-e/--env` option is recommended over positional environment variables
+- 只能通过 `--action` 选项指定 action，位置参数不再支持 action
+- Input format is automatically detected - no need for `-d` or `-u` options
+- For apps with spaces in their names, use quotes around the app ID or path
+- The tool automatically handles URL encoding in file URIs

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -68,6 +68,9 @@ install(FILES ${CMAKE_CURRENT_LIST_DIR}/hooks.d/debFix.sh
             GROUP_READ GROUP_EXECUTE
             WORLD_READ WORLD_EXECUTE
 )
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/bash-completion/dde-am
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions
+)
 
 dtk_add_config_meta_files(APPID ${APPLICATION_SERVICEID}
     FILES

--- a/misc/bash-completion/dde-am
+++ b/misc/bash-completion/dde-am
@@ -1,0 +1,17 @@
+# dde-am completion
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+_comp_dde-am() {
+  local keywords=("-h" "--help" "--list" "--by-user" "-e" "--env" "--action")
+  local cur
+  _comp_initialize
+  if [[ $cur == -* ]]; then
+    COMPREPLY=( $(compgen -W '"${keywords[@]}"' -- "${cur}") )
+  else
+    COMPREPLY=( $( dde-am --list 2>&1 | grep -e "^${cur}.*$" | sort ) )
+  fi
+}
+complete -F _comp_dde-am dde-am
+
+# ex: filetype=bash


### PR DESCRIPTION
Add am-open tool for launching applications via command line

Log:

## Summary by Sourcery

Add a new command-line tool 'am-open' for launching desktop applications via the ApplicationManager D-Bus interface.

New Features:
- Introduce 'am-open' Python CLI to launch applications by app ID, .desktop path, or file URI
- Allow specifying environment variables for the launched application
- Provide built-in usage examples and on-demand help

Enhancements:
- Derive application IDs automatically from standard XDG application directories or fallback to filename
- Log operations and errors with timestamps to /tmp/am-open.log

Build:
- Install the 'am-open' script via CMake into the binary install directory