### PR TITLE
fix: update systemd service dependencies for ApplicationManager1

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -30,7 +30,7 @@ install(FILES ${SYSTEMD_USER_FILE} DESTINATION ${SERVICE_DEST_PATH})
 install(FILES ${SYSTEMD_USER_DROP_IN_FILE} DESTINATION ${SERVICE_DEST_PATH}/app-DDE-.service.d)
 
 # create a symlink to dde-session
-install_symlink(org.desktopspec.ApplicationManager1.service dde-session-initialized.target.wants)
+install_symlink(org.desktopspec.ApplicationManager1.service dde-session-core.target.wants)
 
 # # dbus activate
 configure_file(

--- a/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
+++ b/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
@@ -12,9 +12,8 @@ CollectMode=inactive-or-failed
 Requisite=dde-session-pre.target
 After=dde-session-pre.target
 
-Requisite=dde-session-initialized.target
-PartOf=dde-session-initialized.target
-Before=dde-session-initialized.target
+PartOf=dde-session-core.target
+Before=dde-session-core.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Changed the symlink target in CMakeLists.txt from dde-session-initialized.target to dde-session-core.target. Updated the service file to reflect the new dependencies, replacing references to dde-session-initialized.target with dde-session-core.target. This ensures proper service management and initialization order.

Log: as title