### PR TITLE
fix: add PartOf directive to systemd service override

### DIFF
--- a/misc/systemd/user/app-DDE-.service.d/override.conf
+++ b/misc/systemd/user/app-DDE-.service.d/override.conf
@@ -4,3 +4,6 @@
 
 [Service]
 TimeoutStopSec=3
+
+[Unit]
+PartOf=dde-session-initialized.target


### PR DESCRIPTION
1. Added PartOf=dde-session-initialized.target to systemd service override
2. Ensures the service is properly managed as part of DDE session initialization
3. Maintains service lifecycle alignment with desktop environment
4. Fixes missing newline at end of file

fix: 在 systemd 服务覆盖中添加 PartOf 指令

1. 在 systemd 服务覆盖中添加了 PartOf=dde-session-initialized.target
2. 确保服务作为 DDE 会话初始化的一部分被正确管理
3. 保持服务生命周期与桌面环境同步
4. 修复了文件末尾缺少换行符的问题

Pms: BUG-316855

## Summary by Sourcery

Add PartOf=dde-session-initialized.target to the systemd service override to tie the service lifecycle to the DDE session initialization and fix the missing newline at end of file

Bug Fixes:
- Add missing newline at end of override.conf file

Enhancements:
- Include PartOf=dde-session-initialized.target in the service override to ensure proper management with the DDE session