### PR TITLE
feat: add top-level AutoStart storage and debug logging

### DIFF
--- a/src/applicationmanagerstorage.h
+++ b/src/applicationmanagerstorage.h
@@ -46,6 +46,9 @@ public:
     bool setFirstLaunch(bool first) noexcept;
     [[nodiscard]] bool firstLaunch() const noexcept;
 
+    [[nodiscard]] bool setAutoStart(const QString &appId, bool autoStart) noexcept;
+    [[nodiscard]] bool autoStart(const QString &appId) const noexcept;
+
     [[nodiscard]] static std::shared_ptr<ApplicationManager1Storage>
     createApplicationManager1Storage(const QString &storageDir) noexcept;
 

--- a/src/dbus/applicationmanager1service.h
+++ b/src/dbus/applicationmanager1service.h
@@ -54,7 +54,7 @@ public:
     [[nodiscard]] MimeManager1Service &mimeManager() noexcept { return *m_mimeManager; }
     [[nodiscard]] const MimeManager1Service &mimeManager() const noexcept { return *m_mimeManager; }
     [[nodiscard]] const QStringList &systemdPathEnv() const noexcept { return m_systemdPathEnv; }
-    [[nodiscard]] const QSharedPointer<CompatibilityManager> getCompatibilityManager() const noexcept { return m_compatibilityManager; }
+    [[nodiscard]] QSharedPointer<CompatibilityManager> getCompatibilityManager() const noexcept { return m_compatibilityManager; }
 
 public Q_SLOTS:
     QString Identify(const QDBusUnixFileDescriptor &pidfd,

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -4,24 +4,26 @@
 
 #include "dbus/applicationservice.h"
 #include "APPobjectmanager1adaptor.h"
+#include "applicationadaptor.h"
 #include "applicationchecker.h"
 #include "applicationmanagerstorage.h"
+#include "config.h"
 #include "constant.h"
-#include "global.h"
-#include "iniParser.h"
-#include "propertiesForwarder.h"
 #include "dbus/instanceadaptor.h"
-#include "launchoptions.h"
 #include "desktopentry.h"
 #include "desktopfileparser.h"
-#include "config.h"
-#include <QUuid>
-#include <QStringList>
+#include "global.h"
+#include "iniParser.h"
+#include "launchoptions.h"
+#include "propertiesForwarder.h"
+#include <DConfig>
 #include <QList>
-#include <QUrl>
-#include <QRegularExpression>
 #include <QProcess>
+#include <QRegularExpression>
 #include <QStandardPaths>
+#include <QStringList>
+#include <QUrl>
+#include <QUuid>
 #include <algorithm>
 #include <new>
 #include <qcontainerfwd.h>
@@ -32,7 +34,6 @@
 #include <qtmetamacros.h>
 #include <utility>
 #include <wordexp.h>
-#include <DConfig>
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -217,7 +218,7 @@ QSharedPointer<ApplicationService> ApplicationService::createApplicationService(
     auto error = entry->parse(sourceStream);
 
     if (error != ParserError::NoError) {
-        qWarning() << "parse failed:" << error << app->desktopFileSource().sourcePath();
+        qDebug() << "parse failed:" << error << app->desktopFileSource().sourcePath();
         return nullptr;
     }
 
@@ -423,7 +424,8 @@ ApplicationService::Launch(const QString &action, const QStringList &fields, con
             }
 
             newCommands.push_front(QString{"--SourcePath=%1"}.arg(m_desktopSource.sourcePath()));
-            newCommands.push_front(QString{R"(--unitName=app-DDE-%1@%2.service)"}.arg(escapeApplicationId(this->id()), instanceRandomUUID));
+            newCommands.push_front(
+                QString{R"(--unitName=app-DDE-%1@%2.service)"}.arg(escapeApplicationId(this->id()), instanceRandomUUID));
 
             QProcess process;
             qDebug().noquote() << "launcher :" << m_launcher << "run with commands:" << newCommands;
@@ -1365,13 +1367,8 @@ void ApplicationService::updateAfterLaunch(bool isLaunch) noexcept
     }
 }
 
-void ApplicationService::setAutostartSource(AutostartSource &&source, bool emitAutoStartSignal) noexcept
+void ApplicationService::setAutostartSource(AutostartSource &&source) noexcept
 {
-    if (m_autostartSource.m_filePath == source.m_filePath && m_autostartSource.m_entry == source.m_entry) {
-        return;
-    }
     m_autostartSource = std::move(source);
-    qDebug() << "set autostart source:" << m_autostartSource.m_filePath << m_autostartSource.m_entry.data() << id();
-    if (emitAutoStartSignal) 
-    emit autostartChanged();    
+    emit autostartChanged();
 }

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -202,7 +202,7 @@ private:
     void updateAfterLaunch(bool isLaunch) noexcept;
     static bool shouldBeShown(const std::unique_ptr<DesktopEntry> &entry) noexcept;
     [[nodiscard]] bool autostartCheck(const QString &filePath) const noexcept;
-    void setAutostartSource(AutostartSource &&source, bool emitAutoStartSignal = false) noexcept;
+    void setAutostartSource(AutostartSource &&source) noexcept;
     void appendExtraEnvironments(QVariantMap &runtimeOptions) const noexcept;
     void processCompatibility(const QString &action, QVariantMap &options, QString &execStr);
     [[nodiscard]] ApplicationManager1Service *parent() { return dynamic_cast<ApplicationManager1Service *>(QObject::parent()); }

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -202,7 +202,7 @@ private:
     void updateAfterLaunch(bool isLaunch) noexcept;
     static bool shouldBeShown(const std::unique_ptr<DesktopEntry> &entry) noexcept;
     [[nodiscard]] bool autostartCheck(const QString &filePath) const noexcept;
-    void setAutostartSource(AutostartSource &&source) noexcept;
+    void setAutostartSource(AutostartSource &&source, bool emitAutoStartSignal = false) noexcept;
     void appendExtraEnvironments(QVariantMap &runtimeOptions) const noexcept;
     void processCompatibility(const QString &action, QVariantMap &options, QString &execStr);
     [[nodiscard]] ApplicationManager1Service *parent() { return dynamic_cast<ApplicationManager1Service *>(QObject::parent()); }

--- a/src/dbus/mimemanager1service.cpp
+++ b/src/dbus/mimemanager1service.cpp
@@ -5,7 +5,7 @@
 
 #include "dbus/mimemanager1adaptor.h"
 #include "applicationmanager1service.h"
-#include "applicationservice.h"
+#include "applicationservice.h"  // IWYU pragma: keep
 #include "constant.h"
 
 MimeManager1Service::MimeManager1Service(ApplicationManager1Service *parent)

--- a/src/desktopentry.h
+++ b/src/desktopentry.h
@@ -43,7 +43,6 @@ struct DesktopFile
 
     static std::optional<DesktopFile> searchDesktopFileById(const QString &appId, ParserError &err) noexcept;
     static std::optional<DesktopFile> searchDesktopFileByPath(const QString &desktopFilePath, ParserError &err) noexcept;
-    static std::optional<DesktopFile> searchDesktopFileByPathFilterOwnerAutoStart(const QString &desktopFilePath, ParserError &err) noexcept;
 
     static std::optional<DesktopFile> createTemporaryDesktopFile(const QString &temporaryFile) noexcept;
     static std::optional<DesktopFile> createTemporaryDesktopFile(std::unique_ptr<QFile> temporaryFile) noexcept;

--- a/src/desktopentry.h
+++ b/src/desktopentry.h
@@ -43,6 +43,8 @@ struct DesktopFile
 
     static std::optional<DesktopFile> searchDesktopFileById(const QString &appId, ParserError &err) noexcept;
     static std::optional<DesktopFile> searchDesktopFileByPath(const QString &desktopFilePath, ParserError &err) noexcept;
+    static std::optional<DesktopFile> searchDesktopFileByPathFilterOwnerAutoStart(const QString &desktopFilePath, ParserError &err) noexcept;
+
     static std::optional<DesktopFile> createTemporaryDesktopFile(const QString &temporaryFile) noexcept;
     static std::optional<DesktopFile> createTemporaryDesktopFile(std::unique_ptr<QFile> temporaryFile) noexcept;
 


### PR DESCRIPTION
1. Added new methods setTopLevelAutoStart and getTopLevelAutoStart in ApplicationManager1Storage to manage auto-start settings at storage level
2. Enhanced scanAutoStart to check storage for auto-start settings before removing invalid desktop files
3. Modified ApplicationService::isAutoStart to prioritize storage-based auto-start settings over file system checks
4. Added comprehensive debug logging throughout storage operations including file writes, deletions, and auto-start changes
5. Updated file watching to use lambda with path logging for better debugging
6. This change ensures auto-start settings persist even when desktop files are moved or removed, improving reliability

feat: 添加顶层自动启动存储和调试日志

1. 在 ApplicationManager1Storage 中添加新的 setTopLevelAutoStart 和 getTopLevelAutoStart 方法，用于在存储层管理自动启动设置
2. 增强 scanAutoStart 功能，在删除无效桌面文件前检查存储中的自动启动设置
3. 修改 ApplicationService::isAutoStart 以优先使用基于存储的自动启动设置 而非文件系统检查
4. 在整个存储操作中添加全面的调试日志，包括文件写入、删除和自动启动更改
5. 更新文件监视功能，使用带路径记录的 lambda 表达式以便更好调试
6. 此更改确保即使桌面文件被移动或删除，自动启动设置也能持久化，提高可 靠性

Pms: BUG-330765

## Summary by Sourcery

Add persistent top-level auto-start storage and integrate it into application management, ensuring auto-start settings survive desktop file changes and improve debugging visibility.

New Features:
- Add setTopLevelAutoStart and getTopLevelAutoStart methods to ApplicationManager1Storage for persisting auto-start settings.
- Update ApplicationService to prioritize storage-based auto-start settings in isAutoStart and to update storage in setAutoStart.

Bug Fixes:
- Prevent unintended removal of autostart files when storage marks applications for auto-start.

Enhancements:
- Modify scanAutoStart to consult storage flags before removing invalid autostart files.
- Enhance debug and info logging across storage operations, autostart scanning, file watching, and application reloads.
- Refactor file watcher to use a lambda with path logging for improved traceability.