### PR TITLE
feat: add system autostart directory support

### DIFF
--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -6,6 +6,7 @@
 #include "dbus/applicationmanager1adaptor.h"
 #include "applicationservice.h"
 #include "dbus/AMobjectmanager1adaptor.h"
+#include "global.h"
 #include "systemdsignaldispatcher.h"
 #include "propertiesForwarder.h"
 #include "applicationHooks.h"
@@ -651,6 +652,7 @@ void ApplicationManager1Service::doReloadApplications()
     qInfo() << "reload applications.";
 
     auto desktopFileDirs = getDesktopFileDirs();
+    desktopFileDirs.append(getXDGSystemDirs());  
     auto appIds = m_applicationList.keys();
 
     applyIteratively(

--- a/src/global.h
+++ b/src/global.h
@@ -396,6 +396,11 @@ inline QString getXDGDataHome()
     return XDGDataHome;
 }
 
+inline QStringList getXDGSystemDirs()
+{
+    return QStringList{"/etc/xdg/autostart"};
+}
+
 inline QStringList getXDGDataDirs()
 {
     auto XDGDataDirs = QString::fromLocal8Bit(qgetenv("XDG_DATA_DIRS")).split(':', Qt::SkipEmptyParts);


### PR DESCRIPTION
1. Added getXDGSystemDirs() function to return system-wide autostart directory
2. Modified application reload logic to include system directories alongside user directories
3. This ensures applications from /etc/xdg/autostart are properly loaded and managed
4. Improves compatibility with system-level autostart applications

feat: 添加系统自启动目录支持

1. 新增 getXDGSystemDirs() 函数返回系统级自启动目录
2. 修改应用程序重载逻辑，将系统目录与用户目录一起包含
3. 确保 /etc/xdg/autostart 目录下的应用程序能被正确加载和管理
4. 提升与系统级自启动应用程序的兼容性

注：
因为由于现在reload应用的时候没用加上etc/xdg/autostart会导致autostart的匹配路径存在问题， 会在匹配的时候 remove掉自启动程序（相当于卸载）。从而导致AM会不断的remove 然后加载。

Pms: BUG-335235

## Summary by Sourcery

Support system-wide autostart directories by retrieving and including XDG system dirs in the application reload process

New Features:
- Add getXDGSystemDirs() to return system-level autostart directories

Enhancements:
- Extend application reload to include system autostart dirs alongside user dirs for improved compatibility