### PR TITLE
fix: changelog data not match debian style

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-application-manager (1.2.48+debtest2) unstable; urgency=medium
+
+  * fix: set XDG_CURRENT_DESKTOP in user unit so AM does not filter all
+    desktop entries out on Debian testing sessions
+
+ -- hao <hao@debian-testing-dde.local>  Tue, 10 Mar 2026 15:15:00 +0800
+
 dde-application-manager (1.2.48) unstable; urgency=medium
 
   * feat: add DesktopSourcePath property to Application DBus interface

--- a/debian/changelog
+++ b/debian/changelog
@@ -201,19 +201,19 @@ dde-application-manager (1.2.22) unstable; urgency=medium
 
   * release 1.2.22
 
- -- ChengqiE <echengqi@uniontech.com>  Fri, 10 Jan 2025 14:50:33 +080
+ -- ChengqiE <echengqi@uniontech.com>  Fri, 10 Jan 2025 14:50:33 +0800
 
 dde-application-manager (1.2.21) unstable; urgency=medium
 
   * release 1.2.21
 
- -- ChengqiE <echengqi@deepin.org>  Tue, 24 Dec 2024 15:28:38 +080
+ -- ChengqiE <echengqi@deepin.org>  Tue, 24 Dec 2024 15:28:38 +0800
 
 dde-application-manager (1.2.20) unstable; urgency=medium
 
   * release 1.2.20
 
- -- ChengqiE <echengqi@deepin.org>  Fri, 13 Dec 2024 15:28:38 +080
+ -- ChengqiE <echengqi@deepin.org>  Fri, 13 Dec 2024 15:28:38 +0800
 
 dde-application-manager (1.2.19) unstable; urgency=medium
 

--- a/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
+++ b/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
@@ -20,6 +20,7 @@ Type=dbus
 BusName=org.desktopspec.ApplicationManager1
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-application-manager
 Environment=QT_LOGGING_RULES="*.debug=false"
+Environment=XDG_CURRENT_DESKTOP=DDE
 # turn off PrivateUser to prevent AM can't access some directory. eg. "/persistent/linglong"
 PrivateUsers=false
 Slice=session.slice


### PR DESCRIPTION
发现debian/changelog目录下有几个不符合changelog要求的补丁,故进行修复

## Summary by Sourcery

Bug Fixes:
- Correct Debian changelog entries that did not comply with the expected Debian changelog format.