### PR TITLE
perf: move application manager to dde-session-pre target

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 include(GNUInstallDirs)
@@ -30,7 +30,7 @@ install(FILES ${SYSTEMD_USER_FILE} DESTINATION ${SERVICE_DEST_PATH})
 install(FILES ${SYSTEMD_USER_DROP_IN_FILE} DESTINATION ${SERVICE_DEST_PATH}/app-DDE-.service.d)
 
 # create a symlink to dde-session
-install_symlink(org.desktopspec.ApplicationManager1.service dde-session-core.target.wants)
+install_symlink(org.desktopspec.ApplicationManager1.service dde-session-pre.target.wants)
 
 # dde-autostart service
 configure_file(

--- a/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
+++ b/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
@@ -7,11 +7,8 @@ Description=Deepin Application Manager
 StartLimitBurst=3
 CollectMode=inactive-or-failed
 
-Requisite=dde-session-pre.target
-After=dde-session-pre.target
-
-PartOf=dde-session-core.target
-Before=dde-session-core.target
+PartOf=dde-session-pre.target
+Before=dde-session-pre.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
- Update systemd service to be part of and start before dde-session-pre.target instead of dde-session-core.target.
- Adjust CMakeLists.txt to install the service symlink in dde-session-pre.target.wants.
- This ensures the application manager is ready earlier during the session startup process.

- 将应用管理器服务的 systemd 配置从 dde-session-core.target 调整到 dde-session-pre.target 阶段。
- 调整 CMakeLists.txt，使服务软链接安装到 dde-session-pre.target.wants。
- 确保应用管理器在会话启动过程中更早地准备就绪。

Log: move application manager to dde-session-pre target
Change-Id: I7ea666bfb37e66020c8d5ffafe4d06b4038faef7