### PR TITLE
chore: update changelog to 1.2.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.50) unstable; urgency=medium
+
+  * fix: correct user application directory path and refactor parsers
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:55 +0800
+
 dde-application-manager (1.2.49) unstable; urgency=medium
 
   * refactor: optimize performance, adopt Qt 6 APIs, and fix XDG


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.50

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.50
- 目标分支: master

## Summary by Sourcery

Documentation:
- Update Debian changelog entry to document the 1.2.50 release.