### PR TITLE
chore: update changelog to 1.2.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.51) unstable; urgency=medium
+
+  * perf: move application manager to dde-session-pre target
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 24 Apr 2026 09:58:32 +0800
+
 dde-application-manager (1.2.50) unstable; urgency=medium
 
   * fix: correct user application directory path and refactor parsers


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.51

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.51
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh debian/changelog to document changes for version 1.2.51.