### PR TITLE
fix: Wayland环境下dbus服务启动较慢引起treeland渲染器下dde-launchpad显示应用为空

### DIFF
--- a/apps/dde-application-manager/src/main.cpp
+++ b/apps/dde-application-manager/src/main.cpp
@@ -8,7 +8,6 @@
 #include "global.h"
 #include <QDBusConnection>
 #include <QCoreApplication>
-#include <QGuiApplication>
 
 Q_LOGGING_CATEGORY(DDEAMProf, "dde.am.prof", QtInfoMsg)
 
@@ -40,7 +39,7 @@ int main(int argc, char *argv[])
 #ifdef PROFILING_MODE
     auto start = std::chrono::high_resolution_clock::now();
 #endif
-    const QGuiApplication app{argc, argv};
+    const QCoreApplication app{argc, argv};
 
     auto &bus = ApplicationManager1DBus::instance();
     bus.initGlobalServerBus(DBusType::Session);
@@ -58,6 +57,6 @@ int main(int argc, char *argv[])
     qCInfo(DDEAMProf) << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms";
     return 0;
 #else
-    return QGuiApplication::exec();
+    return QCoreApplication::exec();
 #endif
 }

--- a/src/constant.h
+++ b/src/constant.h
@@ -94,6 +94,7 @@ constexpr static auto &SystemdKill = u"Kill";
 constexpr static auto &SystemdEnvironment = u"Environment";
 constexpr static auto &SystemdGet = u"Get";
 constexpr static auto &SystemdListUnitsByPatterns = u"ListUnitsByPatterns";
+constexpr static int DBusStartupCallTimeoutMs = 1000;
 
 constexpr static auto &MimeappsList = u"mimeapps.list";
 constexpr static auto &MimeinfoCache = u"mimeinfo.cache";

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -155,6 +155,28 @@ void forEachAutostartDesktopFile(T &&func) noexcept
     guard.close();
     return ParsedAutostartEntry{std::move(desktopFile), std::move(entry)};
 }
+
+QStringList pathListFromPathValue(QStringView pathValue) noexcept
+{
+    QStringList ret;
+    const auto tokens = qTokenize(pathValue, u':', Qt::SkipEmptyParts);
+    for (auto token : tokens) {
+        ret.append(token.toString());
+    }
+    return ret;
+}
+
+std::optional<QStringList> pathListFromEnvironment(const QStringList &envs) noexcept
+{
+    const auto path = std::find_if(envs.cbegin(), envs.cend(), [](QStringView env) { return env.startsWith(u"PATH="); });
+    if (path == envs.cend()) {
+        return std::nullopt;
+    }
+
+    return pathListFromPathValue(QStringView{*path}.sliced(5));
+}
+
+constexpr int DeferredStartupDelayMs = 200;
 }  // namespace
 
 ApplicationManager1Service::~ApplicationManager1Service() = default;
@@ -164,24 +186,7 @@ ApplicationManager1Service::ApplicationManager1Service(std::unique_ptr<Identifie
     : m_identifier(std::move(ptr))
     , m_storage(std::move(storage))
 {
-    // Initialize prelaunch splash helper only when running on Wayland.
-    bool isWayland = false;
-    if (auto *app = qobject_cast<QGuiApplication *>(QCoreApplication::instance())) {
-        if (app->nativeInterface<QNativeInterface::QWaylandApplication>() != nullptr) {
-            isWayland = true;
-        }
-    }
-
-    if (isWayland) {
-        m_splashHelper.reset(new (std::nothrow) PrelaunchSplashHelper());
-        if (!m_splashHelper) {
-            qCWarning(amPrelaunchSplash) << "Failed to allocate PrelaunchSplashHelper.";
-        } else {
-            qCInfo(amPrelaunchSplash) << "PrelaunchSplashHelper initialized.";
-        }
-    } else {
-        qCInfo(amPrelaunchSplash) << "Skip PrelaunchSplashHelper (not running on Wayland)";
-    }
+    m_systemdPathEnv = pathListFromPathValue(qEnvironmentVariable("PATH"));
 
     m_reloadTimer.setInterval(500);
     m_reloadTimer.setSingleShot(true);
@@ -238,7 +243,94 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
         qCCritical(DDEAM) << "couldn't watch directory:" << dir;
     }
 
+    auto sysBus = QDBusConnection::systemBus();
+    if (!sysBus.connect(u"org.desktopspec.ApplicationUpdateNotifier1"_s,
+                        u"/org/desktopspec/ApplicationUpdateNotifier1"_s,
+                        u"org.desktopspec.ApplicationUpdateNotifier1"_s,
+                        u"ApplicationUpdated"_s,
+                        this,
+                        SLOT(ReloadApplications()))) {
+        qFatal("connect to ApplicationUpdated failed.");
+    }
+
+    auto storagePtr = m_storage.lock();
+    if (storagePtr) {
+        storagePtr->beginBatchUpdate();
+    }
+
+    scanApplications();
+
+    updateAutostartStatus();
+
+    scanMimeInfos();
+
+    loadHooks();
+
+    if (storagePtr) {
+        if (!storagePtr->setFirstLaunch(false) || !storagePtr->endBatchUpdate()) {
+            qCCritical(DDEAM) << "failed to update state of application manager, some properties may be lost after restart.";
+        }
+    }
+
+    if (auto *ptr = new (std::nothrow)
+                     PropertiesForwarder{fromStaticRaw(DDEApplicationManager1ObjectPath),
+                                         fromStaticRaw(ApplicationManager1Interface),
+                                         this};
+        ptr == nullptr) {
+        qCCritical(DDEAM) << "new PropertiesForwarder of Application Manager failed.";
+    }
+
+    m_startupPhase = false;
+
+    if (!connection.registerService(fromStaticRaw(DDEApplicationManager1ServiceName))) {
+        qFatal("%s", connection.lastError().message().toLocal8Bit().data());
+    }
+
+    qCInfo(DDEAM) << "Application Manager started.";
+
+    QTimer::singleShot(DeferredStartupDelayMs, this, &ApplicationManager1Service::finishDeferredStartup);
+}
+
+PrelaunchSplashHelper *ApplicationManager1Service::splashHelper() noexcept
+{
+    if (!m_splashHelper && !m_splashHelperInitializationTried) {
+        initializePrelaunchSplashHelper();
+    }
+
+    return m_splashHelper.get();
+}
+
+void ApplicationManager1Service::initializePrelaunchSplashHelper() noexcept
+{
+    m_splashHelperInitializationTried = true;
+
+    auto *app = qobject_cast<QGuiApplication *>(QCoreApplication::instance());
+    if (app == nullptr) {
+        qCInfo(amPrelaunchSplash) << "Skip PrelaunchSplashHelper (headless application manager)";
+        return;
+    }
+
+    if (app->nativeInterface<QNativeInterface::QWaylandApplication>() == nullptr) {
+        qCInfo(amPrelaunchSplash) << "Skip PrelaunchSplashHelper (not running on Wayland)";
+        return;
+    }
+
+    m_splashHelper.reset(new (std::nothrow) PrelaunchSplashHelper());
+    if (!m_splashHelper) {
+        qCWarning(amPrelaunchSplash) << "Failed to allocate PrelaunchSplashHelper.";
+        return;
+    }
+
+    qCInfo(amPrelaunchSplash) << "PrelaunchSplashHelper initialized.";
+}
+
+void ApplicationManager1Service::initializeSystemdIntegration() noexcept
+{
     auto &dispatcher = SystemdSignalDispatcher::instance();
+    if (!dispatcher.isAvailable()) {
+        qCWarning(DDEAM) << "Skip systemd integration during startup.";
+        return;
+    }
 
     connect(&dispatcher,
             &SystemdSignalDispatcher::SystemdUnitNew,
@@ -280,83 +372,33 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
             &ApplicationManager1Service::removeInstanceFromApplication);
 
     auto envToPath = [this](const QStringList &envs) {
-        auto path = std::find_if(envs.cbegin(), envs.cend(), [](QStringView env) { return env.startsWith(u"PATH="); });
-        if (path == envs.cend()) {
-            return;
-        }
-
-        auto pathView = QStringView{*path}.sliced(5);
-        auto tokens = qTokenize(pathView, u':', Qt::SkipEmptyParts);
-        m_systemdPathEnv.clear();
-
-        for (auto view : tokens) {
-            m_systemdPathEnv.append(view.toString());
+        if (auto path = pathListFromEnvironment(envs)) {
+            m_systemdPathEnv = std::move(path).value();
         }
     };
 
-    connect(&dispatcher, &SystemdSignalDispatcher::SystemdEnvironmentChanged, envToPath);
+    connect(&dispatcher, &SystemdSignalDispatcher::SystemdEnvironmentChanged, this, envToPath);
 
     auto &con = ApplicationManager1DBus::instance().globalDestBus();
     auto envMsg = QDBusMessage::createMethodCall(
         SystemdService, SystemdObjectPath, fromStaticRaw(SystemdPropInterfaceName), fromStaticRaw(SystemdGet));
     envMsg.setArguments({SystemdInterfaceName, fromStaticRaw(SystemdEnvironment)});
-    auto ret = con.call(envMsg);
+    auto ret = con.call(envMsg, QDBus::Block, DBusStartupCallTimeoutMs);
     if (ret.type() == QDBusMessage::ErrorMessage) {
-        qFatal("%s", ret.errorMessage().toLocal8Bit().data());
+        qCWarning(DDEAM) << "failed to query systemd environment:" << ret.errorMessage();
+    } else if (!ret.arguments().isEmpty()) {
+        envToPath(qdbus_cast<QStringList>(ret.arguments().constFirst().value<QDBusVariant>().variant()));
     }
-    envToPath(qdbus_cast<QStringList>(ret.arguments().constFirst().value<QDBusVariant>().variant()));
-
-    auto sysBus = QDBusConnection::systemBus();
-    if (!sysBus.connect(u"org.desktopspec.ApplicationUpdateNotifier1"_s,
-                        u"/org/desktopspec/ApplicationUpdateNotifier1"_s,
-                        u"org.desktopspec.ApplicationUpdateNotifier1"_s,
-                        u"ApplicationUpdated"_s,
-                        this,
-                        SLOT(ReloadApplications()))) {
-        qFatal("connect to ApplicationUpdated failed.");
-    }
-
-    auto storagePtr = m_storage.lock();
-    if (storagePtr) {
-        storagePtr->beginBatchUpdate();
-    }
-
-    scanApplications();
-
-    updateAutostartStatus();
 
     scanInstances();
+}
 
-    scanMimeInfos();
-
-    loadHooks();
-
-    if (storagePtr) {
-        if (!storagePtr->setFirstLaunch(false) || !storagePtr->endBatchUpdate()) {
-            qCCritical(DDEAM) << "failed to update state of application manager, some properties may be lost after restart.";
-        }
-    }
-
-    if (auto *ptr = new (std::nothrow)
-                     PropertiesForwarder{fromStaticRaw(DDEApplicationManager1ObjectPath),
-                                         fromStaticRaw(ApplicationManager1Interface),
-                                         this};
-        ptr == nullptr) {
-        qCCritical(DDEAM) << "new PropertiesForwarder of Application Manager failed.";
-    }
-
-    m_startupPhase = false;
-
-    qCInfo(DDEAM) << "Application Manager started.";
-
-    for (const auto &application : std::as_const(m_applicationList)) {
-        if (!application->ensurePropertiesForwarder()) {
-            qCCritical(DDEAM) << "failed to initialize PropertiesForwarder for" << application->id();
-        }
-    }
-
-    if (!connection.registerService(fromStaticRaw(DDEApplicationManager1ServiceName))) {
-        qFatal("%s", connection.lastError().message().toLocal8Bit().data());
+void ApplicationManager1Service::updateSessionState() noexcept
+{
+    const auto sessionId = getCurrentSessionId();
+    if (sessionId.isEmpty()) {
+        qCWarning(DDEAM) << "AM couldn't determine current session id.";
+        return;
     }
 
     // TODO: This is a workaround, we will use database at the end.
@@ -364,10 +406,11 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
     const auto fileName = runtimeDir.filePath(u"deepin-application-manager"_s);
     QFile flag{fileName};
 
-    auto sessionId = getCurrentSessionId();
     if (flag.open(QFile::ReadOnly | QFile::ExistingOnly)) {
-        auto content = flag.read(sessionId.size());
-        if (!content.isEmpty() && !sessionId.isEmpty() && content == sessionId) {
+        const auto content = flag.readAll();
+        if (content == sessionId) {
+            m_isNewSession = false;
+            m_sessionStateKnown = true;
             return;
         }
 
@@ -375,12 +418,36 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
     }
 
     if (flag.open(QFile::WriteOnly | QFile::Truncate)) {
-        flag.write(sessionId, sessionId.size());
-        m_isNewSession = true;
+        if (flag.write(sessionId) == sessionId.size()) {
+            m_isNewSession = true;
+            m_sessionStateKnown = true;
+        } else {
+            qCCritical(DDEAM) << "write" << fileName << "failed:" << flag.errorString()
+                              << ", AM couldn't specify if it's a new session.";
+        }
         return;
     }
 
     qCCritical(DDEAM) << "open" << fileName << "failed:" << flag.errorString() << ", AM couldn't specify if it's a new session.";
+}
+
+void ApplicationManager1Service::finishDeferredStartup()
+{
+    if (m_deferredStartupDone) {
+        return;
+    }
+
+    m_deferredStartupDone = true;
+    initializeSystemdIntegration();
+    updateSessionState();
+
+    for (const auto &application : std::as_const(m_applicationList)) {
+        if (!application->ensurePropertiesForwarder()) {
+            qCCritical(DDEAM) << "failed to initialize PropertiesForwarder for" << application->id();
+        }
+    }
+
+    qCInfo(DDEAM) << "Application Manager deferred startup tasks finished.";
 }
 
 void ApplicationManager1Service::addInstanceToApplication(const QString &unitName,
@@ -501,7 +568,7 @@ void ApplicationManager1Service::scanInstances() noexcept
     args << QVariant::fromValue(QStringList{u"running"_s, u"start"_s});
     args << QVariant::fromValue(QStringList{u"dde*"_s, u"deepin*"_s});
     call_message.setArguments(args);
-    auto result = conn.call(call_message);
+    auto result = conn.call(call_message, QDBus::Block, DBusStartupCallTimeoutMs);
     if (result.type() == QDBusMessage::ErrorMessage) {
         qCritical() << "failed to scan existing instances: call to ListUnits failed:" << result.errorMessage();
         return;

--- a/src/dbus/applicationmanager1service.h
+++ b/src/dbus/applicationmanager1service.h
@@ -58,8 +58,9 @@ public:
     [[nodiscard]] const MimeManager1Service &mimeManager() const noexcept { return *m_mimeManager; }
     [[nodiscard]] const QStringList &systemdPathEnv() const noexcept { return m_systemdPathEnv; }
     [[nodiscard]] QSharedPointer<CompatibilityManager> getCompatibilityManager() const noexcept { return m_compatibilityManager; }
-    [[nodiscard]] PrelaunchSplashHelper *splashHelper() const noexcept { return m_splashHelper.get(); }
+    [[nodiscard]] PrelaunchSplashHelper *splashHelper() noexcept;
     [[nodiscard]] bool isNewSession() const noexcept { return m_isNewSession; }
+    [[nodiscard]] bool isSessionStateKnown() const noexcept { return m_sessionStateKnown; }
     [[nodiscard]] bool isStartupPhase() const noexcept { return m_startupPhase; }
 
 public Q_SLOTS:
@@ -84,10 +85,12 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void doReloadApplications();
+    void finishDeferredStartup();
 
 private:
     bool m_startupPhase{true};
     bool m_isNewSession{false};
+    bool m_sessionStateKnown{false};
     std::unique_ptr<Identifier> m_identifier;
     std::weak_ptr<ApplicationManager1Storage> m_storage;
     std::unique_ptr<MimeManager1Service> m_mimeManager;
@@ -101,12 +104,17 @@ private:
     QHash<QString, QSharedPointer<ApplicationService>> m_applicationList;
     QSharedPointer<CompatibilityManager> m_compatibilityManager;
     std::unique_ptr<PrelaunchSplashHelper> m_splashHelper;
+    bool m_splashHelperInitializationTried{false};
+    bool m_deferredStartupDone{false};
 
     void scanMimeInfos() noexcept;
     void scanApplications() noexcept;
     void scanInstances() noexcept;
     void updateAutostartStatus() noexcept;
     void loadHooks() noexcept;
+    void initializeSystemdIntegration() noexcept;
+    void updateSessionState() noexcept;
+    void initializePrelaunchSplashHelper() noexcept;
     void addInstanceToApplication(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;
     void addInstanceToApplication(UnitInfo info, const QDBusObjectPath &systemdUnitPath) noexcept;
     void removeInstanceFromApplication(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -365,8 +365,10 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
     // Suppress splash for system autostart launches or singleton apps with existing instances.
     const bool isAutostartLaunch = options.value(fromStaticRaw(BuiltInAutostartOption), false).toBool();
     if (isAutostartLaunch) {
-        if (!parent()->isNewSession()) {
+        if (parent()->isSessionStateKnown() && !parent()->isNewSession()) {
             safe_sendErrorReply(QDBusError::Failed, "autostart launch has been ignored if not new session.");
+        } else if (!parent()->isSessionStateKnown()) {
+            qCWarning(DDEAM) << "Allow autostart launch before session state is available:" << id();
         }
     }
 

--- a/src/global.h
+++ b/src/global.h
@@ -794,7 +794,7 @@ inline QByteArray getCurrentSessionId()
     msg << fromStaticRaw(SystemdUnitInterfaceName);
     msg << u"InvocationID"_s;
 
-    auto ret = QDBusConnection::sessionBus().call(msg);
+    auto ret = QDBusConnection::sessionBus().call(msg, QDBus::Block, DBusStartupCallTimeoutMs);
     if (ret.type() != QDBusMessage::ReplyMessage) {
         qCWarning(DDEAMUtils) << "get graphical session Id failed:" << ret.errorMessage();
         return {};

--- a/src/systemdsignaldispatcher.h
+++ b/src/systemdsignaldispatcher.h
@@ -17,6 +17,7 @@ public:
         static SystemdSignalDispatcher dispatcher;
         return dispatcher;
     }
+    [[nodiscard]] bool isAvailable() const noexcept { return m_available; }
 Q_SIGNALS:
     void SystemdUnitNew(const QString &unitName, const QDBusObjectPath &systemdUnitPath);
     void SystemdJobNew(const QString &unitName, const QDBusObjectPath &systemdUnitPath);
@@ -30,19 +31,27 @@ private Q_SLOTS:
     void onPropertiesChanged(const QString &interface, const QVariantMap &props, const QStringList &invalid);
 
 private:
+    bool m_available{false};
+
     explicit SystemdSignalDispatcher(QObject *parent = nullptr)
         : QObject(parent)
     {
         using namespace Qt::StringLiterals;
         auto ret = ApplicationManager1DBus::instance().globalDestBus().call(
-            QDBusMessage::createMethodCall(SystemdService, SystemdObjectPath, SystemdInterfaceName, u"Subscribe"_s));
+            QDBusMessage::createMethodCall(SystemdService, SystemdObjectPath, SystemdInterfaceName, u"Subscribe"_s),
+            QDBus::Block,
+            DBusStartupCallTimeoutMs);
         if (ret.type() == QDBusMessage::ErrorMessage) {
-            qFatal("%s", ret.errorMessage().toLocal8Bit().data());
+            qWarning() << "can't subscribe to systemd user manager:" << ret.errorMessage();
+            return;
         }
 
         if (!connectToSignals()) {
-            std::terminate();
+            qWarning() << "can't connect to systemd user manager signals.";
+            return;
         }
+
+        m_available = true;
     }
 
     bool connectToSignals() noexcept;


### PR DESCRIPTION
在 Wayland/treeland 环境下，dde-application-manager D-Bus 服务启动较慢。dde-launchpad 启动时会立即尝试连接该服务并获取应用列表。如果此时服务尚未注册，AppMgr 初始化失败且不会自动重试，导致 AppsModel 获取不到应用数据，启动器应用栏目为空。
于是我治标不治本地增加了重试次数, 当获取应用失败时会重试

修复内容
1. dde-launchpad/src/ddeintegration/appmgr.h 添加 m_fetchRetryCount 成员变量和 MaxFetchRetries 常量，用于控制获取应用列表的重试次数。
2. dde-launchpad/src/ddeintegration/appmgr.cpp 添加 D-Bus 服务监听器：当 org.desktopspec.ApplicationManager1 服务不可用时，使用 QDBusServiceWatcher 监听服务注册事件。一旦服务注册，自动重新初始化 ObjectManager 并获取应用列表。 添加获取失败重试机制：在 fetchAppItems() 中，当获取应用列表失败时，会进行最多 10 次重试，每次间隔 1 秒，避免偶发的 D-Bus 调用失败导致列表为空。
3. dde-launchpad/src/models/appsmodel.cpp 移除了 if (AppMgr::instance()->isValid()) 的条件判断，确保即使 AppMgr 初始不可用时，AppsModel 也能在后续服务可用时接收到 changed() 信号并自动更新模型。