### PR TITLE
chore: update changelog to 1.2.52

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-application-manager (1.2.52) unstable; urgency=medium
+
+  * feat: add application launch event reporting
+  * fix(dde-am): add missing '/'
+
+ -- zhangkun <zhangkun2@uniontech.com>  Sat, 09 May 2026 10:09:02 +0800
+
 dde-application-manager (1.2.51) unstable; urgency=medium
 
   * perf: move application manager to dde-session-pre target


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.52

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.52
- 目标分支: master
