### PR TITLE
fix(test): add missing LaunchType property to identifyService expected result

### DIFF
--- a/tests/ut_applicationmanager.cpp
+++ b/tests/ut_applicationmanager.cpp
@@ -112,6 +112,7 @@ TEST_F(TestApplicationManager, identifyService)
                                   QVariantMap{{QString{"Application"}, ApplicationPath},
                                               {QString{"SystemdUnitPath"}, QDBusObjectPath{"/"}},
                                               {QString{"Launcher"}, QString{"DDE"}},
+                                              {QString{"LaunchType"}, QString{}},
                                               {QString{"Orphaned"}, false}}}};
     EXPECT_EQ(instanceInfo, map);
 


### PR DESCRIPTION
修复测试：为identifyService期望结果补上缺失的LaunchType属性

The LaunchType Q_PROPERTY was added to InstanceService in commit c45e3f2, but the test expectation in identifyService was not updated accordingly, causing the test to fail.

PMS: TASK-389405