### PR TITLE
fix: use escapeApplicationId for systemd unit name in executeCommand

### DIFF
--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -1022,7 +1022,7 @@ QDBusObjectPath ApplicationManager1Service::executeCommand(const QString &progra
         // Escape the program path to create a valid runId
         actualRunId = program;
     }
-    actualRunId = DUtil::escapeToObjectPath(actualRunId);
+    actualRunId = escapeApplicationId(actualRunId);
 
     // Generate random component for systemd unit name
     QString randomComponent = QUuid::createUuid().toString(QUuid::Id128).mid(1, 8);


### PR DESCRIPTION
DUtil::escapeToObjectPath preserves '/' (valid in D-Bus object paths), but systemd unit names require escaping of '/'. This caused StartTransientUnit to silently fail because systemd rejected unit names with literal '/'.

Use escapeApplicationId instead, which follows systemd unit name spec (replaces '/' with '-').

Pms: BUG-360839
Change-Id: Ic7b15a79aed95c15d80e98038426ca78ead944fd