### PR TITLE
chore: update changelog to 1.2.54

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.54) unstable; urgency=medium
+
+  * Release 1.2.54
+
+ -- zhangkun <zhangkun2@uniontech.com>  Mon, 25 May 2026 11:33:24 +0800
+
 dde-application-manager (1.2.53) unstable; urgency=medium
 
   * fix: use escapeApplicationId for systemd unit name in executeCommand


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.54

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.54
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entry to document version 1.2.54.