### PR TITLE
fix(dbus): attach launch metadata to pending instances

### DIFF
--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -248,22 +248,17 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
     connect(&dispatcher,
             &SystemdSignalDispatcher::SystemdUnitNew,
             this,
-            qOverload<const QString &, const QDBusObjectPath &>(&ApplicationManager1Service::addInstanceToApplication));
+            &ApplicationManager1Service::onUnitNew);
     connect(&dispatcher,
             &SystemdSignalDispatcher::SystemdJobNew,
             this,
             [this](const QString &unitName, const QDBusObjectPath &systemdUnitPath) {
                 auto info = processUnitName(unitName);
-                if (!info) {
-                    return;
-                }
-
-                if (info->applicationID.isEmpty()) {
+                if (!info || info->applicationID.isEmpty()) {
                     return;
                 }
 
                 auto app = m_applicationList.value(info->applicationID);
-
                 if (!app) {
                     return;
                 }
@@ -276,13 +271,13 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
 
                 qCDebug(DDEAM) << "add Instance " << unitName << "on JobNew, " << app->instances().size();
 
-                addInstanceToApplication(std::move(info).value(), systemdUnitPath);
+                onUnitNew(unitName, systemdUnitPath);
             });
 
     connect(&dispatcher,
             &SystemdSignalDispatcher::SystemdUnitRemoved,
             this,
-            &ApplicationManager1Service::removeInstanceFromApplication);
+            &ApplicationManager1Service::onUnitRemoved);
 
     auto envToPath = [this](const QStringList &envs) {
         auto path = std::find_if(envs.cbegin(), envs.cend(), [](QStringView env) { return env.startsWith(u"PATH="); });
@@ -388,158 +383,45 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
     qCCritical(DDEAM) << "open" << fileName << "failed:" << flag.errorString() << ", AM couldn't specify if it's a new session.";
 }
 
-void ApplicationManager1Service::addPendingInstanceLaunchType(const QString &instanceId, const QString &launchType) noexcept
-{
-    m_pendingInstanceLaunchTypes.insert(instanceId, launchType);
-}
-
-void ApplicationManager1Service::removePendingInstanceLaunchType(const QString &instanceId) noexcept
-{
-    m_pendingInstanceLaunchTypes.remove(instanceId);
-}
-
-QString ApplicationManager1Service::takePendingInstanceLaunchType(const QString &appId, const QString &instanceId) noexcept
-{
-    auto launchType = m_pendingInstanceLaunchTypes.take(instanceId);
-    if (launchType.isEmpty()) {
-        qCWarning(DDEAM) << "missing pending launch type for app" << appId << "instance" << instanceId;
-        launchType = u"unknown"_s;
-    }
-
-    return launchType;
-}
-
-void ApplicationManager1Service::addInstanceToApplication(const QString &unitName,
-                                                          const QDBusObjectPath &systemdUnitPath) noexcept
+void ApplicationManager1Service::onUnitNew(const QString &unitName,
+                                           const QDBusObjectPath &systemdUnitPath) noexcept
 {
     auto info = processUnitName(unitName);
-    if (!info) {
+    if (!info || info->applicationID.isEmpty()) {
         return;
     }
 
-    addInstanceToApplication(std::move(info).value(), systemdUnitPath);
-}
-
-void ApplicationManager1Service::addInstanceToApplication(UnitInfo info, const QDBusObjectPath &systemdUnitPath) noexcept
-{
-    auto appId = std::move(info.applicationID);
-    auto launcher = std::move(info.launcher);
-    auto instanceId = std::move(info.instanceID);
-
-    if (appId.isEmpty()) {
+    auto app = m_applicationList.value(info->applicationID);
+    if (!app) {
+        qCWarning(DDEAM) << "couldn't find app" << info->applicationID << "in application manager.";
         return;
     }
 
+    auto instanceId = info->instanceID;
     if (instanceId.isEmpty()) {
         instanceId = QUuid::createUuid().toString(QUuid::Id128);
     }
 
-    auto app = m_applicationList.value(appId);
-
-    if (!app) {
-        qCWarning(DDEAM) << "couldn't find app" << appId << "in application manager.";
-        return;
-    }
-
-    app->updateAfterLaunch(sender() != nullptr);  // activate by signal
-
-    const auto &applicationPath = app->applicationPath().path();
-
-    const auto launchType = takePendingInstanceLaunchType(appId, instanceId);
-
-    if (!app->addOneInstance(instanceId, applicationPath, systemdUnitPath.path(), launcher, launchType)) {
-        qCCritical(DDEAM) << "failed to add instance" << systemdUnitPath.path() << "to app" << appId;
-    }
-
-    using namespace Qt::StringLiterals;
-    auto &bus = ApplicationManager1DBus::instance().globalDestBus();
-    auto watcher = new UnitResultWatcher(systemdUnitPath, this);
-    connect(watcher, &UnitResultWatcher::resultReady, this, &ApplicationManager1Service::onUnitResultReady);
-    auto connected = bus.connect(QString::fromUtf8(SystemdService),
-                                 systemdUnitPath.path(),
-                                 QString::fromUtf16(SystemdPropInterfaceName),
-                                 u"PropertiesChanged"_s,
-                                 watcher,
-                                 SLOT(handlePropertyChanged(QString,QVariantMap,QStringList)));
-    qCDebug(DDEAM) << "UnitResultWatcher connect for" << systemdUnitPath.path() << "result:" << connected;
+    app->handleUnitStarted(instanceId, systemdUnitPath.path(), info->launcher, {});
 }
 
-void ApplicationManager1Service::removeInstanceFromApplication(const QString &unitName,
-                                                               const QDBusObjectPath &systemdUnitPath) noexcept
+void ApplicationManager1Service::onUnitRemoved(const QString &unitName,
+                                               const QDBusObjectPath &systemdUnitPath) noexcept
 {
     auto info = processUnitName(unitName);
-    if (!info) {
+    if (!info || info->applicationID.isEmpty()) {
         return;
     }
 
-    auto appId = std::move(info->applicationID);
-
-    if (appId.isEmpty()) {
-        return;
-    }
-
-    auto app = m_applicationList.value(appId);
-
+    auto app = m_applicationList.value(info->applicationID);
     if (!app) {
-        qWarning() << "couldn't find app" << appId << "in application manager.";
-        return;
-    }
-
-    const auto &appIns = app->applicationInstances();
-
-    auto instanceIt =
-        std::find_if(appIns.cbegin(), appIns.cend(), [&systemdUnitPath](const QSharedPointer<InstanceService> &value) {
-            return value->property("SystemdUnitPath") == systemdUnitPath;
+        orphanedInstances.removeIf([&systemdUnitPath](const QSharedPointer<InstanceService> &ptr) {
+            return (ptr->property("SystemdUnitPath").value<QDBusObjectPath>() == systemdUnitPath);
         });
-
-    if (instanceIt != appIns.cend()) {
-        auto result = m_unitResults.take(systemdUnitPath.path());
-        qCDebug(DDEAM) << "removeInstance: unitPath=" << systemdUnitPath.path() << "cached result=" << result;
-
-        static const QSet<QString> launchFailedResults{u"start-limit-hit"_s, u"resources"_s, u"exec-condition"_s, u"protocol"_s, u"timeout"_s};
-
-        if (launchFailedResults.contains(result)) {
-            EventReporter::reportAppLaunchFailed(app->eventAppId(),
-                                                 QStringLiteral("systemd result: %1").arg(result),
-                                                 app->x_linglong(),
-                                                 (*instanceIt)->launchType(),
-                                                 (*instanceIt)->instanceId());
-        } else if (!result.isEmpty() && result != u"success"_s) {
-            QStringList logArgs{"--user", QStringLiteral("--unit=%1").arg(unitName),
-                                "-p", "warning", "-n", "6", "-o", "cat", "-o", "with-unit", "--no-pager"};
-            QProcess logProc;
-            logProc.start("journalctl", logArgs);
-            QString logInfo;
-            if (!logProc.waitForStarted(1000)) {
-                qCWarning(DDEAM) << "journalctl failed to start for unit:" << unitName;
-            } else if (!logProc.waitForFinished(3000)) {
-                qCWarning(DDEAM) << "journalctl timeout for unit:" << unitName;
-                logProc.kill();
-            } else {
-                logInfo = QString::fromUtf8(logProc.readAllStandardOutput());
-            }
-
-            EventReporter::reportAppAbnormalExit(app->eventAppId(),
-                                                 (*instanceIt)->launchType(),
-                                                 unitName,
-                                                 logInfo,
-                                                 app->x_linglong(),
-                                                 (*instanceIt)->instanceId());
-        }
-
-        app->removeOneInstance(instanceIt.key());
         return;
     }
 
-    orphanedInstances.removeIf([&systemdUnitPath](const QSharedPointer<InstanceService> &ptr) {
-        return (ptr->property("SystemdUnitPath").value<QDBusObjectPath>() == systemdUnitPath);
-    });
-}
-
-void ApplicationManager1Service::onUnitResultReady(const QDBusObjectPath &unitPath, const QString &result)
-{
-    qCDebug(DDEAM) << "onUnitResultReady: unitPath=" << unitPath.path() << "result=" << result;
-    m_unitResults.insert(unitPath.path(), result);
+    app->handleUnitRemoved(systemdUnitPath.path(), unitName);
 }
 
 void ApplicationManager1Service::scanMimeInfos() noexcept
@@ -591,7 +473,7 @@ void ApplicationManager1Service::scanInstances() noexcept
     QList<SystemdUnitDBusMessage> units;
     v.value<QDBusArgument>() >> units;
     for (const auto &unit : std::as_const(units)) {
-        this->addInstanceToApplication(unit.name, unit.objectPath);
+        this->onUnitNew(unit.name, unit.objectPath);
     }
 }
 

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -402,7 +402,7 @@ void ApplicationManager1Service::onUnitNew(const QString &unitName,
         instanceId = QUuid::createUuid().toString(QUuid::Id128);
     }
 
-    app->handleUnitStarted(instanceId, systemdUnitPath.path(), info->launcher, {});
+    app->handleUnitStarted(instanceId, systemdUnitPath.path(), info->launcher, {}, sender() != nullptr);
 }
 
 void ApplicationManager1Service::onUnitRemoved(const QString &unitName,

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -388,6 +388,27 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
     qCCritical(DDEAM) << "open" << fileName << "failed:" << flag.errorString() << ", AM couldn't specify if it's a new session.";
 }
 
+void ApplicationManager1Service::addPendingInstanceLaunchType(const QString &instanceId, const QString &launchType) noexcept
+{
+    m_pendingInstanceLaunchTypes.insert(instanceId, launchType);
+}
+
+void ApplicationManager1Service::removePendingInstanceLaunchType(const QString &instanceId) noexcept
+{
+    m_pendingInstanceLaunchTypes.remove(instanceId);
+}
+
+QString ApplicationManager1Service::takePendingInstanceLaunchType(const QString &appId, const QString &instanceId) noexcept
+{
+    auto launchType = m_pendingInstanceLaunchTypes.take(instanceId);
+    if (launchType.isEmpty()) {
+        qCWarning(DDEAM) << "missing pending launch type for app" << appId << "instance" << instanceId;
+        launchType = u"unknown"_s;
+    }
+
+    return launchType;
+}
+
 void ApplicationManager1Service::addInstanceToApplication(const QString &unitName,
                                                           const QDBusObjectPath &systemdUnitPath) noexcept
 {
@@ -424,7 +445,9 @@ void ApplicationManager1Service::addInstanceToApplication(UnitInfo info, const Q
 
     const auto &applicationPath = app->applicationPath().path();
 
-    if (!app->addOneInstance(instanceId, applicationPath, systemdUnitPath.path(), launcher, app->launchType(), app->launchUniqueId())) {
+    const auto launchType = takePendingInstanceLaunchType(appId, instanceId);
+
+    if (!app->addOneInstance(instanceId, applicationPath, systemdUnitPath.path(), launcher, launchType)) {
         qCCritical(DDEAM) << "failed to add instance" << systemdUnitPath.path() << "to app" << appId;
     }
 
@@ -480,7 +503,7 @@ void ApplicationManager1Service::removeInstanceFromApplication(const QString &un
                                                  QStringLiteral("systemd result: %1").arg(result),
                                                  app->x_linglong(),
                                                  (*instanceIt)->launchType(),
-                                                 (*instanceIt)->launchUniqueId());
+                                                 (*instanceIt)->instanceId());
         } else if (!result.isEmpty() && result != u"success"_s) {
             QStringList logArgs{"--user", QStringLiteral("--unit=%1").arg(unitName),
                                 "-p", "warning", "-n", "6", "-o", "cat", "-o", "with-unit", "--no-pager"};
@@ -501,7 +524,7 @@ void ApplicationManager1Service::removeInstanceFromApplication(const QString &un
                                                  unitName,
                                                  logInfo,
                                                  app->x_linglong(),
-                                                 (*instanceIt)->launchUniqueId());
+                                                 (*instanceIt)->instanceId());
         }
 
         app->removeOneInstance(instanceIt.key());

--- a/src/dbus/applicationmanager1service.h
+++ b/src/dbus/applicationmanager1service.h
@@ -59,6 +59,8 @@ private:
 class ApplicationManager1Service final : public QObject, protected QDBusContext
 {
     Q_OBJECT
+    friend class ApplicationService;
+
 public:
     explicit ApplicationManager1Service(std::unique_ptr<Identifier> ptr,
                                         std::weak_ptr<ApplicationManager1Storage> storage) noexcept;
@@ -131,6 +133,7 @@ private:
     bool m_pendingReload{false};
     QHash<QString, QSharedPointer<ApplicationService>> m_applicationList;
     QHash<QString, QString> m_unitResults;
+    QHash<QString, QString> m_pendingInstanceLaunchTypes;
     QSharedPointer<CompatibilityManager> m_compatibilityManager;
     std::unique_ptr<PrelaunchSplashHelper> m_splashHelper;
 
@@ -139,6 +142,9 @@ private:
     void scanInstances() noexcept;
     void updateAutostartStatus() noexcept;
     void loadHooks() noexcept;
+    void addPendingInstanceLaunchType(const QString &instanceId, const QString &launchType) noexcept;
+    void removePendingInstanceLaunchType(const QString &instanceId) noexcept;
+    QString takePendingInstanceLaunchType(const QString &appId, const QString &instanceId) noexcept;
     void addInstanceToApplication(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;
     void addInstanceToApplication(UnitInfo info, const QDBusObjectPath &systemdUnitPath) noexcept;
     void removeInstanceFromApplication(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;

--- a/src/dbus/applicationmanager1service.h
+++ b/src/dbus/applicationmanager1service.h
@@ -116,7 +116,6 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void doReloadApplications();
-    void onUnitResultReady(const QDBusObjectPath &unitPath, const QString &result);
 
 private:
     bool m_startupPhase{true};
@@ -132,8 +131,6 @@ private:
     bool m_isReloading{false};
     bool m_pendingReload{false};
     QHash<QString, QSharedPointer<ApplicationService>> m_applicationList;
-    QHash<QString, QString> m_unitResults;
-    QHash<QString, QString> m_pendingInstanceLaunchTypes;
     QSharedPointer<CompatibilityManager> m_compatibilityManager;
     std::unique_ptr<PrelaunchSplashHelper> m_splashHelper;
 
@@ -142,12 +139,8 @@ private:
     void scanInstances() noexcept;
     void updateAutostartStatus() noexcept;
     void loadHooks() noexcept;
-    void addPendingInstanceLaunchType(const QString &instanceId, const QString &launchType) noexcept;
-    void removePendingInstanceLaunchType(const QString &instanceId) noexcept;
-    QString takePendingInstanceLaunchType(const QString &appId, const QString &instanceId) noexcept;
-    void addInstanceToApplication(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;
-    void addInstanceToApplication(UnitInfo info, const QDBusObjectPath &systemdUnitPath) noexcept;
-    void removeInstanceFromApplication(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;
+    void onUnitNew(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;
+    void onUnitRemoved(const QString &unitName, const QDBusObjectPath &systemdUnitPath) noexcept;
     QSharedPointer<ApplicationService> addApplication(DesktopFile desktopFileSource, std::unique_ptr<DesktopEntry> entry) noexcept;
 };
 

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -527,7 +527,7 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
         qCWarning(amPrelaunchSplash) << "Skip prelaunch splash (no parent ApplicationManager1Service)" << id();
     }
 
-    parent()->addPendingInstanceLaunchType(instanceRandomUUID, launchType);
+    m_pendingLaunchTypes.insert(instanceRandomUUID, launchType);
 
     auto &jobManager = parent()->jobManager();
     return jobManager.addJob(
@@ -605,7 +605,7 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
                                                      x_linglong(),
                                                      launchType,
                                                      instanceRandomUUID);
-                parent()->removePendingInstanceLaunchType(instanceRandomUUID);
+                m_pendingLaunchTypes.remove(instanceRandomUUID);
                 return QDBusError::Failed;
             }
 
@@ -1139,6 +1139,96 @@ void ApplicationService::removeAllInstance() noexcept
     for (auto it = m_Instances.constBegin(); it != m_Instances.constEnd(); ++it) {
         removeOneInstance(it.key());
     }
+}
+
+void ApplicationService::handleUnitStarted(const QString &instanceId,
+                                           const QString &systemdUnitPath,
+                                           const QString &launcher,
+                                           const QString &launchType) noexcept
+{
+    using namespace Qt::StringLiterals;
+
+    updateAfterLaunch(sender() != nullptr);
+
+    auto lt = launchType;
+    if (lt.isEmpty()) {
+        lt = m_pendingLaunchTypes.take(instanceId);
+    }
+    if (lt.isEmpty()) {
+        qCWarning(DDEAM) << "missing pending launch type for app" << id() << "instance" << instanceId;
+        lt = u"unknown"_s;
+    }
+
+    if (!addOneInstance(instanceId, m_applicationPath.path(), systemdUnitPath, launcher, lt)) {
+        qCCritical(DDEAM) << "failed to add instance" << systemdUnitPath << "to app" << id();
+    }
+
+    auto watcher = new UnitResultWatcher(QDBusObjectPath{systemdUnitPath}, this);
+    connect(watcher, &UnitResultWatcher::resultReady, this, [this](const QDBusObjectPath &unitPath, const QString &result) {
+        qCDebug(DDEAM) << "onUnitResultReady: unitPath=" << unitPath.path() << "result=" << result;
+        m_unitResults.insert(unitPath.path(), result);
+    });
+    auto &bus = ApplicationManager1DBus::instance().globalDestBus();
+    auto connected = bus.connect(QString::fromUtf8(SystemdService),
+                                 systemdUnitPath,
+                                 QString::fromUtf16(SystemdPropInterfaceName),
+                                 u"PropertiesChanged"_s,
+                                 watcher,
+                                 SLOT(handlePropertyChanged(QString,QVariantMap,QStringList)));
+    qCDebug(DDEAM) << "UnitResultWatcher connect for" << systemdUnitPath << "result:" << connected;
+}
+
+void ApplicationService::handleUnitRemoved(const QString &systemdUnitPath, const QString &unitName) noexcept
+{
+    using namespace Qt::StringLiterals;
+
+    const QDBusObjectPath unitPath{systemdUnitPath};
+
+    auto instanceIt =
+        std::find_if(m_Instances.cbegin(), m_Instances.cend(), [&unitPath](const QSharedPointer<InstanceService> &value) {
+            return value->property("SystemdUnitPath") == unitPath;
+        });
+
+    if (instanceIt == m_Instances.cend()) {
+        return;
+    }
+
+    auto result = m_unitResults.take(systemdUnitPath);
+    qCDebug(DDEAM) << "removeInstance: unitPath=" << systemdUnitPath << "cached result=" << result;
+
+    static const QSet<QString> launchFailedResults{
+        u"start-limit-hit"_s, u"resources"_s, u"exec-condition"_s, u"protocol"_s, u"timeout"_s};
+
+    if (launchFailedResults.contains(result)) {
+        EventReporter::reportAppLaunchFailed(eventAppId(),
+                                             QStringLiteral("systemd result: %1").arg(result),
+                                             x_linglong(),
+                                             (*instanceIt)->launchType(),
+                                             (*instanceIt)->instanceId());
+    } else if (!result.isEmpty() && result != u"success"_s) {
+        QStringList logArgs{"--user", QStringLiteral("--unit=%1").arg(unitName),
+                            "-p", "warning", "-n", "6", "-o", "cat", "-o", "with-unit", "--no-pager"};
+        QProcess logProc;
+        logProc.start("journalctl", logArgs);
+        QString logInfo;
+        if (!logProc.waitForStarted(1000)) {
+            qCWarning(DDEAM) << "journalctl failed to start for unit:" << unitName;
+        } else if (!logProc.waitForFinished(3000)) {
+            qCWarning(DDEAM) << "journalctl timeout for unit:" << unitName;
+            logProc.kill();
+        } else {
+            logInfo = QString::fromUtf8(logProc.readAllStandardOutput());
+        }
+
+        EventReporter::reportAppAbnormalExit(eventAppId(),
+                                             (*instanceIt)->launchType(),
+                                             unitName,
+                                             logInfo,
+                                             x_linglong(),
+                                             (*instanceIt)->instanceId());
+    }
+
+    removeOneInstance(instanceIt.key());
 }
 
 void ApplicationService::detachAllInstance() noexcept

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -375,10 +375,8 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
     if (launchType.isEmpty()) {
         launchType = u"unknown"_s;
     }
-    setLaunchType(launchType);
-    auto launchUniqueId = QUuid::createUuid().toString(QUuid::WithoutBraces);
-    setLaunchUniqueId(launchUniqueId);
-    qCDebug(DDEAM) << "launch app:" << id() << "launchType:" << launchType << "uniqueID:" << launchUniqueId;
+    auto instanceRandomUUID = QUuid::createUuid().toString(QUuid::Id128);
+    qCDebug(DDEAM) << "launch app:" << id() << "launchType:" << launchType << "uniqueID:" << instanceRandomUUID;
 
     if (isAutostartLaunch) {
         if (!parent()->isNewSession()) {
@@ -507,10 +505,7 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
         cmds.push_back("-e");  // run all original execution commands in deepin-terminal
     }
 
-    // Generate instance UUID early so splash and job lambda share the same id.
-    auto instanceRandomUUID = QUuid::createUuid().toString(QUuid::Id128);
-
-    EventReporter::reportAppLaunch(eventAppId(), QDateTime::currentMSecsSinceEpoch(), x_linglong(), launchType, launchUniqueId);
+    EventReporter::reportAppLaunch(eventAppId(), QDateTime::currentMSecsSinceEpoch(), x_linglong(), launchType, instanceRandomUUID);
 
     // Notify the compositor to show a splash screen (after validation passes).
     if (isAutostartLaunch) {
@@ -532,10 +527,12 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
         qCWarning(amPrelaunchSplash) << "Skip prelaunch splash (no parent ApplicationManager1Service)" << id();
     }
 
+    parent()->addPendingInstanceLaunchType(instanceRandomUUID, launchType);
+
     auto &jobManager = parent()->jobManager();
     return jobManager.addJob(
         m_applicationPath.path(),
-        [this, task, instanceRandomUUID = std::move(instanceRandomUUID), cmds = std::move(cmds), launchType, launchUniqueId](
+        [this, task, instanceRandomUUID = std::move(instanceRandomUUID), cmds = std::move(cmds), launchType](
             const QVariant &value) mutable -> QVariant {
             QStringList newCommands;
             const int estimatedSize = 6 + cmds.size() + task.command.size() + (value.isValid() ? 1 : 0);
@@ -607,7 +604,8 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
                                                      QStringLiteral("app-launch-helper exited with code %1").arg(exitCode),
                                                      x_linglong(),
                                                      launchType,
-                                                     launchUniqueId);
+                                                     instanceRandomUUID);
+                parent()->removePendingInstanceLaunchType(instanceRandomUUID);
                 return QDBusError::Failed;
             }
 
@@ -1087,10 +1085,9 @@ bool ApplicationService::addOneInstance(const QString &instanceId,
                                         const QString &application,
                                         const QString &systemdUnitPath,
                                         const QString &launcher,
-                                        const QString &launchType,
-                                        const QString &uniqueId) noexcept
+                                        const QString &launchType) noexcept
 {
-    auto *service = new (std::nothrow) InstanceService{instanceId, application, systemdUnitPath, launcher, launchType, uniqueId};
+    auto *service = new (std::nothrow) InstanceService{instanceId, application, systemdUnitPath, launcher, launchType};
     if (service == nullptr) {
         qCritical() << "couldn't new InstanceService.";
         return false;

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -1144,11 +1144,12 @@ void ApplicationService::removeAllInstance() noexcept
 void ApplicationService::handleUnitStarted(const QString &instanceId,
                                            const QString &systemdUnitPath,
                                            const QString &launcher,
-                                           const QString &launchType) noexcept
+                                           const QString &launchType,
+                                           bool isNewLaunch) noexcept
 {
     using namespace Qt::StringLiterals;
 
-    updateAfterLaunch(sender() != nullptr);
+    updateAfterLaunch(isNewLaunch);
 
     auto lt = launchType;
     if (lt.isEmpty()) {

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -128,12 +128,6 @@ public:
     [[nodiscard]] const QString &getLauncher() const noexcept { return m_launcher; }
     void setLauncher(const QString &launcher) noexcept { m_launcher = launcher; }
 
-    void setLaunchType(const QString &launchType) noexcept { m_launchType = launchType; }
-    [[nodiscard]] const QString &launchType() const noexcept { return m_launchType; }
-
-    void setLaunchUniqueId(const QString &uniqueId) noexcept { m_launchUniqueId = uniqueId; }
-    [[nodiscard]] const QString &launchUniqueId() const noexcept { return m_launchUniqueId; }
-
     void setEventAppId(const QString &appId) noexcept { m_eventAppId = appId; }
     [[nodiscard]] QString eventAppId() const noexcept { return m_eventAppId.isEmpty() ? id() : m_eventAppId; }
 
@@ -141,8 +135,7 @@ public:
                         const QString &application,
                         const QString &systemdUnitPath,
                         const QString &launcher,
-                        const QString &launchType = {},
-                        const QString &uniqueId = {}) noexcept;
+                        const QString &launchType = {}) noexcept;
     void recoverInstances(const QList<QDBusObjectPath> &instanceList) noexcept;
     void removeOneInstance(const QDBusObjectPath &instance) noexcept;
     void removeAllInstance() noexcept;
@@ -221,8 +214,6 @@ private:
     QHash<QDBusObjectPath, QSharedPointer<InstanceService>> m_Instances;
     QSet<QString> m_splashInstanceIds;
     bool m_propertiesForwarderInitialized{false};
-    QString m_launchType;
-    QString m_launchUniqueId;
     QString m_eventAppId;
     void updateAfterLaunch(bool isLaunch) noexcept;
     static bool shouldBeShown(const std::unique_ptr<DesktopEntry> &entry) noexcept;

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -136,6 +136,11 @@ public:
                         const QString &systemdUnitPath,
                         const QString &launcher,
                         const QString &launchType = {}) noexcept;
+    void handleUnitStarted(const QString &instanceId,
+                           const QString &systemdUnitPath,
+                           const QString &launcher,
+                           const QString &launchType) noexcept;
+    void handleUnitRemoved(const QString &systemdUnitPath, const QString &unitName) noexcept;
     void recoverInstances(const QList<QDBusObjectPath> &instanceList) noexcept;
     void removeOneInstance(const QDBusObjectPath &instance) noexcept;
     void removeAllInstance() noexcept;
@@ -212,6 +217,8 @@ private:
     DesktopFile m_desktopSource;
     QSharedPointer<DesktopEntry> m_entry{nullptr};
     QHash<QDBusObjectPath, QSharedPointer<InstanceService>> m_Instances;
+    QHash<QString, QString> m_pendingLaunchTypes;
+    QHash<QString, QString> m_unitResults;
     QSet<QString> m_splashInstanceIds;
     bool m_propertiesForwarderInitialized{false};
     QString m_eventAppId;

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -139,7 +139,8 @@ public:
     void handleUnitStarted(const QString &instanceId,
                            const QString &systemdUnitPath,
                            const QString &launcher,
-                           const QString &launchType) noexcept;
+                           const QString &launchType,
+                           bool isNewLaunch) noexcept;
     void handleUnitRemoved(const QString &systemdUnitPath, const QString &unitName) noexcept;
     void recoverInstances(const QList<QDBusObjectPath> &instanceList) noexcept;
     void removeOneInstance(const QDBusObjectPath &instance) noexcept;

--- a/src/dbus/instanceservice.cpp
+++ b/src/dbus/instanceservice.cpp
@@ -8,13 +8,12 @@
 #include <QDBusMessage>
 #include "global.h"
 
-InstanceService::InstanceService(QString instanceId, QString application, QString systemdUnitPath, QString launcher, const QString &launchType, const QString &uniqueId)
+InstanceService::InstanceService(QString instanceId, QString application, QString systemdUnitPath, QString launcher, const QString &launchType)
     : m_Launcher(std::move(launcher))
     , m_instanceId(std::move(instanceId))
     , m_Application(std::move(application))
     , m_SystemdUnitPath(std::move(systemdUnitPath))
     , m_launchType(launchType)
-    , m_uniqueId(uniqueId)
 {
     if (auto *tmp = new (std::nothrow)
                      PropertiesForwarder{application + "/" + instanceId, fromStaticRaw(InstanceInterface), this};

--- a/src/dbus/instanceservice.h
+++ b/src/dbus/instanceservice.h
@@ -27,7 +27,6 @@ public:
 
     [[nodiscard]] const QString &instanceId() const noexcept { return m_instanceId; }
     [[nodiscard]] const QString &launchType() const noexcept { return m_launchType; }
-    [[nodiscard]] const QString &launchUniqueId() const noexcept { return m_uniqueId; }
 
 public Q_SLOTS:
     void KillAll(int signal);
@@ -37,11 +36,10 @@ Q_SIGNALS:
 
 private:
     friend class ApplicationService;
-    InstanceService(QString instanceId, QString application, QString systemdUnitPath, QString launcher, const QString &launchType = {}, const QString &uniqueId = {});
+    InstanceService(QString instanceId, QString application, QString systemdUnitPath, QString launcher, const QString &launchType = {});
     bool m_orphaned{false};
     QString m_Launcher;
     QString m_launchType;
-    QString m_uniqueId;
     QString m_instanceId;
     QDBusObjectPath m_Application;
     QDBusObjectPath m_SystemdUnitPath;


### PR DESCRIPTION
Move launch metadata off ApplicationService state and keep it pending per instance until the systemd unit is matched.

将启动元数据从 ApplicationService 状态中移出，并按实例暂存，
直到 systemd unit 被匹配并消费。

Log: 将启动元数据改为按实例暂存
PMS: TASK-389405
Influence: 避免并发启动时 launchType 和实例标识串写，实例信息更准确。

## Summary by Sourcery

Track application launch metadata per instance and wire it through instance lifecycle and reporting.

Bug Fixes:
- Prevent launch metadata from being overwritten or mis-associated when multiple instances launch concurrently.
- Log systemd unit completion using the instance identifier instead of a separate launch UUID to improve accuracy.

Enhancements:
- Store pending launch types in ApplicationManager1Service until systemd units are matched, then assign them to instances.
- Simplify InstanceService and ApplicationService by removing stored launch UUID state and relying on instance IDs for logging and reporting.