### PR TITLE
chore: update changelog to 1.2.55

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-application-manager (1.2.55) unstable; urgency=medium
+
+  * feat(dde-am): use -- separator to pass extra launch arguments
+  * fix(popup): improve popup background with blur and palette
+  * fix(dbus): pass isNewLaunch flag to fix LastLaunchedTime stats
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:32:58 +0800
+
 dde-application-manager (1.2.54) unstable; urgency=medium
 
   * Release 1.2.54


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.55

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.55
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entry to document version 1.2.55.