### PR TITLE
refactor(eventreporter): load skip-event appIds from DConfig at startup

### DIFF
--- a/misc/dsg/configs/dde-application-manager/org.deepin.dde.application-manager.json
+++ b/misc/dsg/configs/dde-application-manager/org.deepin.dde.application-manager.json
@@ -21,6 +21,16 @@
             "description": "Ignore blacklisted environment variables before launching app",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "skipEventAppIds": {
+            "value": ["dde-file-manager"],
+            "serial": 0,
+            "flags": [],
+            "name": "Skip event reporting for these application IDs",
+            "name[zh_CN]": "跳过这些应用的埋点上报",
+            "description": "Applications that report events by themselves; application-manager will skip duplicate reporting.",
+            "permissions": "readonly",
+            "visibility": "public"
         }
     }
 }

--- a/src/constant.h
+++ b/src/constant.h
@@ -65,6 +65,7 @@ constexpr static auto &ApplicationManagerToolsConfig = u"org.deepin.dde.am";
 constexpr static auto &ApplicationManagerConfig = u"org.deepin.dde.application-manager";
 constexpr static auto &AppExtraEnvironments = u"appExtraEnvironments";
 constexpr static auto &AppEnvironmentsBlacklist = u"appEnvironmentsBlacklist";
+constexpr static auto &SkipEventAppIds = u"skipEventAppIds";
 
 constexpr static auto &CompatibilityConfigFilePath = u"/var/lib/compatible/compatibleDesktop.json";
 

--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -331,6 +331,8 @@ void ApplicationManager1Service::initService(QDBusConnection &connection) noexce
 
     loadHooks();
 
+    EventReporter::instance().initialize();
+
     if (storagePtr) {
         if (!storagePtr->setFirstLaunch(false) || !storagePtr->endBatchUpdate()) {
             qCCritical(DDEAM) << "failed to update state of application manager, some properties may be lost after restart.";
@@ -779,6 +781,9 @@ void ApplicationManager1Service::doReloadApplications()
     updateAutostartStatus();
 
     reloadMimeInfos();
+
+    EventReporter::instance().initialize();
+
     m_isReloading = false;
 
     if (m_pendingReload) {

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -511,7 +511,7 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
         cmds.push_back("-e");  // run all original execution commands in deepin-terminal
     }
 
-    EventReporter::reportAppLaunch(eventAppId(), QDateTime::currentMSecsSinceEpoch(), x_linglong(), launchType, instanceRandomUUID);
+    EventReporter::instance().reportAppLaunch(eventAppId(), QDateTime::currentMSecsSinceEpoch(), x_linglong(), launchType, instanceRandomUUID);
 
     // Notify the compositor to show a splash screen (after validation passes).
     if (isAutostartLaunch) {
@@ -608,7 +608,7 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
             auto exitCode = process.exitCode();
             if (exitCode != 0) {
                 qWarning() << "Launch Application Failed";
-                EventReporter::reportAppLaunchFailed(eventAppId(),
+                EventReporter::instance().reportAppLaunchFailed(eventAppId(),
                                                      QStringLiteral("app-launch-helper exited with code %1").arg(exitCode),
                                                      x_linglong(),
                                                      launchType,
@@ -1209,7 +1209,7 @@ void ApplicationService::handleUnitRemoved(const QString &systemdUnitPath, const
         u"start-limit-hit"_s, u"resources"_s, u"exec-condition"_s, u"protocol"_s, u"timeout"_s};
 
     if (launchFailedResults.contains(result)) {
-        EventReporter::reportAppLaunchFailed(eventAppId(),
+        EventReporter::instance().reportAppLaunchFailed(eventAppId(),
                                              QStringLiteral("systemd result: %1").arg(result),
                                              x_linglong(),
                                              (*instanceIt)->launchType(),
@@ -1229,7 +1229,7 @@ void ApplicationService::handleUnitRemoved(const QString &systemdUnitPath, const
             logInfo = QString::fromUtf8(logProc.readAllStandardOutput());
         }
 
-        EventReporter::reportAppAbnormalExit(eventAppId(),
+        EventReporter::instance().reportAppAbnormalExit(eventAppId(),
                                              (*instanceIt)->launchType(),
                                              unitName,
                                              logInfo,

--- a/src/eventreporter.cpp
+++ b/src/eventreporter.cpp
@@ -3,49 +3,78 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "eventreporter.h"
+#include "config.h"
+#include "constant.h"
+#include "global.h"
 
 #ifdef HAVE_DDE_API_EVENTLOGGER
 #include <dde-api/eventlogger.hpp>
 #endif
+#include <DConfig>
+
 #include <QLoggingCategory>
+#include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QProcess>
 #include <QHash>
+#include <algorithm>
+#include <memory>
 
 Q_LOGGING_CATEGORY(amEventReporter, "dde.am.event.reporter")
 
-namespace {
-QHash<QString, QString> &versionCache()
+EventReporter &EventReporter::instance()
 {
-    static QHash<QString, QString> cache;
-    return cache;
+    static EventReporter reporter;
+    return reporter;
 }
 
-QHash<QString, QString> &pakTypeCache()
+void EventReporter::initialize()
 {
-    static QHash<QString, QString> cache;
-    return cache;
-}
+    DCORE_USE_NAMESPACE
+    std::unique_ptr<DConfig> config(DConfig::create(
+        fromStaticRaw(ApplicationServiceID),
+        fromStaticRaw(ApplicationManagerConfig)));
 
-struct AppPackageInfo {
-    QString version;
-    QString pakType;
-};
-
-AppPackageInfo queryAppPackageInfo(const QString &appId, bool isLinglong)
-{
-    auto &vCache = versionCache();
-    auto &pCache = pakTypeCache();
-
-    bool versionCached = vCache.contains(appId);
-    bool pakTypeCached = pCache.contains(appId);
-    if (versionCached && pakTypeCached) {
-        return {vCache.value(appId), pCache.value(appId)};
+    if (!config || !config->isValid()) {
+        qCInfo(amEventReporter) << "DConfig not available, skip event filter disabled.";
+        return;
     }
 
-    AppPackageInfo info{versionCached ? vCache.value(appId) : QString{},
-                        pakTypeCached ? pCache.value(appId) : QString{}};
+    m_skipEventAppIds = config->value(fromStaticRaw(SkipEventAppIds)).toStringList();
+    qCInfo(amEventReporter) << "skip event appIds:" << m_skipEventAppIds;
+}
+
+bool EventReporter::shouldSkip(const QString &appId) const
+{
+    if (appId.isEmpty())
+        return false;
+
+    if (m_skipEventAppIds.contains(appId)) {
+        qCDebug(amEventReporter) << "skip all events for appId:" << appId;
+        return true;
+    }
+
+    return false;
+}
+
+EventReporter::CacheEntry EventReporter::queryAppPackageInfo(const QString &appId, bool isLinglong)
+{
+    auto cacheIt = m_cache.constFind(appId);
+    if (cacheIt != m_cache.constEnd()) {
+        qint64 age = QDateTime::currentMSecsSinceEpoch() - cacheIt->timestamp;
+        if (age < kCacheTimeoutMs) {
+            m_cache[appId].timestamp = QDateTime::currentMSecsSinceEpoch();
+            return *cacheIt;
+        }
+        qCDebug(amEventReporter) << "cache stale for appId:" << appId << "age:" << age << "ms";
+    }
+
+    CacheEntry info;
+    if (cacheIt != m_cache.constEnd()) {
+        info.version = cacheIt->version;
+        info.pakType = cacheIt->pakType;
+    }
 
     qCDebug(amEventReporter) << "query package info for appId:" << appId;
 
@@ -86,16 +115,31 @@ AppPackageInfo queryAppPackageInfo(const QString &appId, bool isLinglong)
         info.pakType = "unknown";
     }
 
-    vCache.insert(appId, info.version);
-    pCache.insert(appId, info.pakType);
+    info.timestamp = QDateTime::currentMSecsSinceEpoch();
 
+    // LRU eviction: if it's a new entry and at capacity, remove the oldest
+    if (cacheIt == m_cache.constEnd() && m_cache.size() >= kMaxCacheSize) {
+        auto oldest = std::min_element(m_cache.constKeyValueBegin(),
+                                       m_cache.constKeyValueEnd(),
+                                       [](const auto &a, const auto &b) {
+                                           return a.second.timestamp < b.second.timestamp;
+                                       });
+        if (oldest != m_cache.constKeyValueEnd()) {
+            qCDebug(amEventReporter) << "evict cache for appId:" << oldest->first;
+            m_cache.remove(oldest->first);
+        }
+    }
+
+    m_cache.insert(appId, info);
     return info;
-}
 }
 
 void EventReporter::reportAppLaunch(const QString &appName, qint64 timeMs, bool isLinglong, const QString &launchType, const QString &uniqueID)
 {
 #ifdef HAVE_DDE_API_EVENTLOGGER
+    if (shouldSkip(appName))
+        return;
+
     auto info = queryAppPackageInfo(appName, isLinglong);
     DDE_EventLogger::EventLogger::instance().writeEventLog({
         1000610001,
@@ -120,6 +164,9 @@ void EventReporter::reportAppLaunch(const QString &appName, qint64 timeMs, bool 
 void EventReporter::reportAppLaunchFailed(const QString &appName, const QString &errors, bool isLinglong, const QString &launchType, const QString &uniqueID)
 {
 #ifdef HAVE_DDE_API_EVENTLOGGER
+    if (shouldSkip(appName))
+        return;
+
     auto info = queryAppPackageInfo(appName, isLinglong);
     DDE_EventLogger::EventLogger::instance().writeEventLog({
         1000610002,
@@ -144,6 +191,9 @@ void EventReporter::reportAppLaunchFailed(const QString &appName, const QString 
 void EventReporter::reportAppAbnormalExit(const QString &appName, const QString &launchType, const QString &exec, const QString &logInfo, bool isLinglong, const QString &uniqueID)
 {
 #ifdef HAVE_DDE_API_EVENTLOGGER
+    if (shouldSkip(appName))
+        return;
+
     auto info = queryAppPackageInfo(appName, isLinglong);
     DDE_EventLogger::EventLogger::instance().writeEventLog({
         1000600012,

--- a/src/eventreporter.h
+++ b/src/eventreporter.h
@@ -4,11 +4,35 @@
 
 #pragma once
 
+#include <QHash>
 #include <QString>
-#include <QJsonObject>
+#include <QStringList>
 
-namespace EventReporter {
-void reportAppLaunch(const QString &appName, qint64 timeMs, bool isLinglong, const QString &launchType = {}, const QString &uniqueID = {});
-void reportAppLaunchFailed(const QString &appName, const QString &errors, bool isLinglong, const QString &launchType = {}, const QString &uniqueID = {});
-void reportAppAbnormalExit(const QString &appName, const QString &launchType, const QString &exec, const QString &logInfo, bool isLinglong, const QString &uniqueID = {});
-}
+class EventReporter
+{
+public:
+    static EventReporter &instance();
+
+    void initialize();
+    void reportAppLaunch(const QString &appName, qint64 timeMs, bool isLinglong, const QString &launchType = {}, const QString &uniqueID = {});
+    void reportAppLaunchFailed(const QString &appName, const QString &errors, bool isLinglong, const QString &launchType = {}, const QString &uniqueID = {});
+    void reportAppAbnormalExit(const QString &appName, const QString &launchType, const QString &exec, const QString &logInfo, bool isLinglong, const QString &uniqueID = {});
+
+private:
+    EventReporter() = default;
+
+    struct CacheEntry {
+        QString version;
+        QString pakType;
+        qint64 timestamp = 0;
+    };
+
+    bool shouldSkip(const QString &appId) const;
+    CacheEntry queryAppPackageInfo(const QString &appId, bool isLinglong);
+
+    QStringList m_skipEventAppIds;
+    QHash<QString, CacheEntry> m_cache;
+
+    static constexpr int kMaxCacheSize = 128;
+    static constexpr qint64 kCacheTimeoutMs = 600'000;  // 10 minutes
+};


### PR DESCRIPTION
Replace the hardcoded skip list with a DConfig-based configuration that is loaded once when ApplicationManager1Service initializes. The skip event app IDs can now be configured at system level via dsg configs without recompiling.

将硬编码的跳过应用列表改为 DConfig 配置驱动，在
ApplicationManager1Service 初始化时一次性加载。跳过埋点
上报的应用 ID 现在可通过系统级 DSG 配置管理，无需重新编译。

Log: 将跳过上报列表改为 DConfig 配置
PMS: BUG-361065
Influence: dde-file-manager 等应用的埋点跳过逻辑由配置文件控制，
           支持运行时通过 dconfig-cli 查看，重启后生效。