### PR TITLE
fix: validate file name to prevent path traversal in addUserApplication and deleteUserApplication

### DIFF
--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -827,6 +827,13 @@ QString ApplicationManager1Service::addUserApplication(const QVariantMap &deskto
 
     const QDir appDir{getUserApplicationDir()};
     const auto &filePath = appDir.filePath(name);
+
+    // 校验 name 必须是合法文件名，不能包含路径信息
+    if (name.contains(QDir::separator()) || name == QStringLiteral("..")) {
+        safe_sendErrorReply(QDBusError::Failed, QStringLiteral("invalid file name: must be a file name, not a path."));
+        return {};
+    }
+
     QFile file{filePath};
     const auto fileExists = file.exists();
     bool shouldRewrite = false;
@@ -903,6 +910,12 @@ void ApplicationManager1Service::deleteUserApplication(const QString &app_id) no
 
     const QDir appDir{getUserApplicationDir()};
     const auto &filePath = appDir.filePath(app_id % desktopSuffix);
+
+    // 校验 app_id 必须是合法文件名，不能包含路径信息
+    if (app_id.contains(QDir::separator()) || app_id == QStringLiteral("..")) {
+        safe_sendErrorReply(QDBusError::Failed, QStringLiteral("invalid app_id: must be a file name, not a path."));
+        return;
+    }
 
     if (const QFileInfo info{filePath}; !info.exists() || !info.isFile()) {
         safe_sendErrorReply(QDBusError::Failed, QString{"file not exists:%1"}.arg(info.absoluteFilePath()));


### PR DESCRIPTION
## Summary

Add file name validation to `addUserApplication` and `deleteUserApplication` DBus methods to prevent path traversal attacks.

The `name` parameter of `addUserApplication` and the `app_id` parameter of `deleteUserApplication` were directly concatenated into file paths without validation. An attacker could pass values like `../../../tmp/evil.desktop` or `/tmp/evil.desktop` to write/delete files outside the intended `~/.local/share/applications/` directory.

## Changes

- `src/dbus/applicationmanager1service.cpp`: Added file name checks using `QDir::separator()` and `".."` comparison in both methods

## Validation

- Built and deployed to debug machine (10.20.9.188)
- Tested with Python dbus client:
  - `../../../tmp/evil.desktop` → rejected with error
  - `/tmp/evil.desktop` → rejected with error
  - Normal file names pass through

## PMS

BUG-364827 BUG-364825