### PR TITLE
fix: wait for treeland socket before application manager

### DIFF
--- a/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
+++ b/misc/systemd/user/org.desktopspec.ApplicationManager1.service.in
@@ -10,6 +10,8 @@ CollectMode=inactive-or-failed
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target
 
+After=treeland-sd.service
+
 [Service]
 Type=dbus
 BusName=org.desktopspec.ApplicationManager1


### PR DESCRIPTION
## Summary
- Add ordering after treeland-sd.service for ApplicationManager1.
- Keep the service in dde-session-pre.target while avoiding startup before the Treeland Wayland socket is ready.

## Test plan
- git diff --check
- Inspected remote journal showing the first startup failed before wl_display was available and the restart succeeded after Treeland initialized.