### PR TITLE
chore: update changelog to 1.2.56

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-application-manager (1.2.56) unstable; urgency=medium
+
+  * feat: pass whitelisted env vars to launched applications in dde-am
+  * fix: wait for treeland socket before application manager
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:45:35 +0800
+
 dde-application-manager (1.2.55) unstable; urgency=medium
 
   * feat(dde-am): use -- separator to pass extra launch arguments


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.56

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.56
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to release 1.2.56 targeting master.