### PR TITLE
fix: guard missing autostart desktop entry

### DIFF
--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -406,7 +406,13 @@ QDBusObjectPath ApplicationService::Launch(const QString &action, const QStringL
     }();
 
     if (desktopEntry == nullptr) {
-        safe_sendErrorReply(QDBusError::Failed, "This application is not set to autostart.");
+        const QString msg = "This application is not set to autostart.";
+        qWarning() << msg << "app:" << id()
+                   << "isAutostartLaunch:" << isAutostartLaunch
+                   << "desktopSource:" << m_desktopSource.sourcePath()
+                   << "autostartSource:" << m_autostartSource.m_filePath;
+        safe_sendErrorReply(QDBusError::Failed, msg);
+        return {};
     }
 
     // ignore action if it's not supported or autostart launch


### PR DESCRIPTION
## Summary
- Avoid dereferencing a null DesktopEntry when handling invalid autostart launch requests.
- Log the affected app id and desktop/autostart source before returning the existing D-Bus error.

## Test plan
- cmake --build build --target dde-application-manager

Pms: BUG-366575