### PR TITLE
chore: update changelog to 1.2.57

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-manager (1.2.57) unstable; urgency=medium
+
+  * fix: guard missing autostart desktop entry
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:37:44 +0800
+
 dde-application-manager (1.2.56) unstable; urgency=medium
 
   * feat: pass whitelisted env vars to launched applications in dde-am


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.2.57

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.2.57
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to document version 1.2.57.