### PR TITLE
fix: sync generated autostart desktop entries

### DIFF
--- a/src/dbus/applicationmanager1service.cpp
+++ b/src/dbus/applicationmanager1service.cpp
@@ -526,11 +526,13 @@ void ApplicationManager1Service::updateAutostartStatus() noexcept
             }
 
             app->setAutostartSource({sourcePath, std::move(parsedSource->entry)});
+            app->syncGeneratedAutostartEntry();
             return false;
         }
 
         if (auto existApp = m_applicationList.value(desktopId); existApp) {
             existApp->setAutostartSource({sourcePath, std::move(parsedSource->entry)});
+            existApp->syncGeneratedAutostartEntry();
             return false;
         }
 
@@ -738,6 +740,8 @@ void ApplicationManager1Service::updateApplication(const QSharedPointer<Applicat
     if (destApp->m_desktopSource != desktopFile && destApp->isAutoStart()) {
         destApp->m_desktopSource = std::move(desktopFile);
     }
+
+    destApp->syncGeneratedAutostartEntry();
 }
 
 void ApplicationManager1Service::ReloadApplications()

--- a/src/dbus/applicationservice.cpp
+++ b/src/dbus/applicationservice.cpp
@@ -941,16 +941,101 @@ bool ApplicationService::autostartCheck() const noexcept
 
 bool ApplicationService::isAutoStart() const noexcept
 {
-    if (m_autostartSource.m_filePath.isEmpty()) {
+    if (!autostartSourceFileExists()) {
         return false;
     }
 
     return autostartCheck();
 }
 
+bool ApplicationService::autostartSourceFileExists() const noexcept
+{
+    return !m_autostartSource.m_filePath.isEmpty() && QFile::exists(m_autostartSource.m_filePath);
+}
+
+bool ApplicationService::hasGeneratedAutostartSource() const noexcept
+{
+    auto group = m_autostartSource.m_entry.group(fromStaticRaw(DesktopFileEntryKey));
+    if (!group.has_value()) {
+        return false;
+    }
+
+    return group->get().contains(fromStaticRaw(DesktopEntryXDeepinGenerateSource));
+}
+
+bool ApplicationService::saveAutostartEntry(const QString &fileName, const DesktopEntry &entry) noexcept
+{
+    const QFileInfo autostartFileInfo{fileName};
+    if (autostartFileInfo.isSymLink()) {
+        qWarning() << "refuse to overwrite symlink autostart file:" << fileName;
+        return false;
+    }
+
+    QFile autostartFile{fileName};
+    if (!autostartFile.open(QFile::WriteOnly | QFile::Text | QFile::Truncate)) {
+        qWarning() << "open file" << fileName << "failed:" << autostartFile.error();
+        return false;
+    }
+
+    auto content = toString(entry.data()).toLocal8Bit();
+    auto writeBytes = autostartFile.write(content);
+
+    if (writeBytes != content.size() || !autostartFile.flush()) {
+        qWarning() << "incomplete write:" << autostartFile.error();
+        return false;
+    }
+
+    return true;
+}
+
+void ApplicationService::syncGeneratedAutostartEntry() noexcept
+{
+    if (!m_entry || !autostartSourceFileExists()) {
+        return;
+    }
+
+    QFile autostartFile{m_autostartSource.m_filePath};
+    if (!autostartFile.open(QFile::ReadOnly | QFile::Text)) {
+        qWarning() << "open file" << m_autostartSource.m_filePath << "failed:" << autostartFile.error();
+        return;
+    }
+
+    DesktopEntry currentEntry;
+    if (currentEntry.parse(autostartFile) != ParserError::NoError) {
+        qWarning() << "parse autostart file" << m_autostartSource.m_filePath << "failed";
+        return;
+    }
+
+    auto group = currentEntry.group(fromStaticRaw(DesktopFileEntryKey));
+    if (!group.has_value() || !group->get().contains(fromStaticRaw(DesktopEntryXDeepinGenerateSource))) {
+        return;
+    }
+
+    DesktopEntry newEntry = *m_entry;
+    newEntry.insert(fromStaticRaw(DesktopFileEntryKey), fromStaticRaw(DesktopEntryXDeepinGenerateSource), m_desktopSource.sourcePath());
+
+    auto hidden = currentEntry.value(fromStaticRaw(DesktopFileEntryKey), fromStaticRaw(DesktopEntryHidden));
+    if (hidden) {
+        auto hiddenValue = hidden->get();
+        newEntry.insert(fromStaticRaw(DesktopFileEntryKey), fromStaticRaw(DesktopEntryHidden), std::move(hiddenValue));
+    }
+
+    if (!saveAutostartEntry(m_autostartSource.m_filePath, newEntry)) {
+        return;
+    }
+
+    setAutostartSource({m_autostartSource.m_filePath, newEntry});
+}
+
 void ApplicationService::setAutoStart(bool autostart) noexcept
 {
     if (isAutoStart() == autostart) {
+        return;
+    }
+
+    if (!m_entry) {
+        qWarning() << "set autostart failed, desktop entry is null:" << id();
+        safe_sendErrorReply(QDBusError::InternalError);
         return;
     }
 
@@ -962,16 +1047,11 @@ void ApplicationService::setAutoStart(bool autostart) noexcept
     }
 
     auto fileName = startDir.filePath(m_desktopSource.desktopId() % desktopSuffix);
-    QFile autostartFile{fileName};
-    if (!autostartFile.open(QFile::WriteOnly | QFile::Text | QFile::Truncate)) {
-        qWarning() << "open file" << fileName << "failed:" << autostartFile.error();
-        safe_sendErrorReply(QDBusError::Failed);
-        return;
-    }
-
     DesktopEntry newEntry;
     QString originalSource;
-    if (!m_autostartSource.m_entry.data().isEmpty()) {
+    const bool shouldReuseAutostartEntry = autostartSourceFileExists() && !hasGeneratedAutostartSource()
+        && !m_autostartSource.m_entry.data().isEmpty();
+    if (shouldReuseAutostartEntry) {
         newEntry = m_autostartSource.m_entry;
 
         auto source = newEntry.value(fromStaticRaw(DesktopFileEntryKey), fromStaticRaw(DesktopEntryXDeepinGenerateSource));
@@ -988,15 +1068,13 @@ void ApplicationService::setAutoStart(bool autostart) noexcept
     newEntry.insert(fromStaticRaw(DesktopFileEntryKey), fromStaticRaw(DesktopEntryXDeepinGenerateSource), originalSource);
     newEntry.insert(fromStaticRaw(DesktopFileEntryKey), fromStaticRaw(DesktopEntryHidden), !autostart);
 
-    setAutostartSource({fileName, newEntry});
-
-    auto hideAutostart = toString(newEntry.data()).toLocal8Bit();
-    auto writeBytes = autostartFile.write(hideAutostart);
-
-    if (writeBytes != hideAutostart.size() || !autostartFile.flush()) {
-        qWarning() << "incomplete write:" << autostartFile.error();
+    if (!saveAutostartEntry(fileName, newEntry)) {
+        qWarning() << "set autostart failed:" << id() << "autostart:" << autostart << "file:" << fileName;
+        safe_sendErrorReply(QDBusError::Failed);
+        return;
     }
 
+    setAutostartSource({fileName, newEntry});
     emit autostartChanged();
 }
 

--- a/src/dbus/applicationservice.h
+++ b/src/dbus/applicationservice.h
@@ -226,7 +226,11 @@ private:
     void updateAfterLaunch(bool isLaunch) noexcept;
     static bool shouldBeShown(const std::unique_ptr<DesktopEntry> &entry) noexcept;
     [[nodiscard]] bool autostartCheck() const noexcept;
+    [[nodiscard]] bool autostartSourceFileExists() const noexcept;
+    [[nodiscard]] bool hasGeneratedAutostartSource() const noexcept;
     void setAutostartSource(AutostartSource &&source) noexcept;
+    bool saveAutostartEntry(const QString &fileName, const DesktopEntry &entry) noexcept;
+    void syncGeneratedAutostartEntry() noexcept;
     void appendExtraEnvironments(QVariantMap &runtimeOptions) const noexcept;
     void processCompatibility(const QString &action, QVariantMap &options, QString &execStr);
     [[nodiscard]] LaunchTask processExec(const QString &str, const QStringList& fields, const QString& workingDir) noexcept;


### PR DESCRIPTION
## Summary
- Refresh AM-generated autostart desktop files when application desktop entries are reloaded.
- Avoid reusing stale in-memory autostart entries after the generated file is deleted.
- Preserve the current Hidden value from disk while syncing generated autostart entries.

## Test plan
- cmake --build build --target dde-application-manager

## Summary by Sourcery

Synchronize and persist generated autostart desktop entries with their source application entries while ensuring file existence checks and error handling are improved.

New Features:
- Introduce synchronization of generated autostart entries with updated application desktop entries, preserving user Hidden state.

Bug Fixes:
- Avoid using stale in-memory autostart entries when the underlying autostart desktop file has been removed.
- Ensure generated autostart entries are refreshed when application desktop entries are reloaded.

Enhancements:
- Add reusable helpers for checking autostart source file existence, detecting generated autostart sources, and saving autostart desktop entries.
- Improve autostart toggling logic to reuse existing non-generated entries safely and emit errors on failed writes.